### PR TITLE
Render GuideSidebar below content on mobile viewports

### DIFF
--- a/src/components/GuideSidebar.js
+++ b/src/components/GuideSidebar.js
@@ -4,28 +4,14 @@ import Link from './Link'
 import {scale, rhythm, headerFontFamily} from '../utils/typography'
 import {accent} from '../utils/colors'
 
-export default class GuideSidebar extends React.Component {
-  state = {closed: true}
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.current !== this.props.current) {
-      this.setState({closed: true})
-    }
-  }
-  render() {
-    return <div css={styles.container}>
-      <div
-        css={styles.navToggle}
-        onClick={() => this.setState({closed: !this.state.closed})}
-      >
-        Navigation
-      </div>
-      <div css={[styles.contents, this.state.closed && styles.hiddenContents]}>
-        <Link to={this.props.search}>Search</Link>
-        <Node current={this.props.current} item={this.props.root} root depth={0} />
-      </div>
+const GuideSidebar = ({props, current, root, search}) => (
+  <div css={styles.container}>
+    <div css={styles.contents}>
+      <Link to={search}>Search</Link>
+      <Node current={current} item={root} root depth={0} />
     </div>
-  }
-}
+  </div>
+)
 
 const Node = ({current, root, item: {title, relativePath, children}, depth}) => {
   const linkStyles = [styles.link, styles['link' + depth], relativePath === current && styles.currentLink]
@@ -38,6 +24,8 @@ const Node = ({current, root, item: {title, relativePath, children}, depth}) => 
     </div>
   : <Link css={[styles.node, linkStyles]} to={relativePath}>{title}</Link>
 }
+
+export default GuideSidebar
 
 export const sidebarFragment = graphql`
   fragment guideSidebar on RootQueryType {
@@ -75,22 +63,8 @@ const styles = {
     padding: `${rhythm(1/3)} ${rhythm(1/2)}`,
   },
 
-  hiddenContents: {
-    [phablet]: {
-      display: 'none',
-    }
-  },
-
-  navToggle: {
-    backgroundColor: '#444',
-    color: 'white',
-    padding: `${rhythm(1/3)} ${rhythm(1/2)}`,
-    alignSelf: 'stretch',
-    display: 'none',
-    cursor: 'pointer',
-    [phablet]: {
-      display: 'flex',
-    }
+  node: {
+    
   },
 
   li: {

--- a/src/templates/Guide.js
+++ b/src/templates/Guide.js
@@ -83,7 +83,7 @@ const styles = {
   contentSection: {
     flexDirection: 'row',
     '@media(max-width: 800px)': {
-      flexDirection: 'column',
+      flexDirection: 'column-reverse',
     },
   },
   sidebar: {


### PR DESCRIPTION
@jaredly I accidentally rebased with `master` instead of `source` (force of habit) and it closed out my original PR at https://github.com/reasonml/reasonml.github.io/pull/12 😄 

This PR implements https://github.com/reasonml/reasonml.github.io/pull/12 with only CSS using `flex-direction`.