### PR TITLE
Content updates, remove backticks from proper nouns

### DIFF
--- a/src/pages/guide/javascript/syntax-cheetsheet.md
+++ b/src/pages/guide/javascript/syntax-cheetsheet.md
@@ -5,21 +5,21 @@ order: 1
 
 Reason resembles a typed subset of modern JavaScript (the good parts).
 
-`Reason`'s syntax is easy to learn, and if you know modern
-`JavaScript` you can usually read and make sense of `Reason` code without
-actually learning `Reason`.
-The OCaml language that `Reason` uses provides many new concepts that
-deliver a much more expressive, yet often more constrained experience. `Reason`
+Reason's syntax is easy to learn, and if you know modern
+JavaScript you can usually read and make sense of Reason code without
+actually learning Reason.
+The OCaml language that Reason uses provides many new concepts that
+deliver a much more expressive, yet often more constrained experience. Reason
 helps you learn those new concepts more quickly and reap the benefits of the
-`OCaml` compiler sooner.
+OCaml compiler sooner.
 
 
-The end result is that `Reason`:
+The end result is that Reason:
 
 - Allows writing code that a wide range of developers can **easily read**.
 - Can be **mastered quickly**.
 - Delivers the true **"if it compiles, it works"** experience pioneered by the `ML` language.
-- Compiles to **bare metal** native binaries, *or* to `JavaScript`.
+- Compiles to **bare metal** native binaries, *or* to JavaScript.
 
 ### Basic Language Primitives
 
@@ -60,8 +60,8 @@ no static types           |  <pre>type point = {x: int, mutable y: int};</pre>
 <pre>{...point, x: 30}</pre>       |  <pre>{...point, x: 30}</pre>
 
 ### Blocks
-In `Reason`, "sequence expressions" are created with `{}` and evaluate to their
-last statement. In `JavaScript`, this can be simulated via a temporary variable
+In Reason, "sequence expressions" are created with `{}` and evaluate to their
+last statement. In JavaScript, this can be simulated via a temporary variable
 which must be created in an invalid state, then later mutated.
 
 <table>
@@ -90,7 +90,7 @@ let res = {
 
 ### Lambdas
 
-`JavaScript` has two different kinds of functions, whereas `Reason` only has one.
+JavaScript has two different kinds of functions, whereas Reason only has one.
 
 JavaScript                            |   Reason
 --------------------------------------|--------------------------------
@@ -100,8 +100,8 @@ JavaScript                            |   Reason
 
 
 
-The primary difference between modern (ES6) `JavaScript` and `Reason` lambdas is that
-`Reason` lambdas begin with the word `fun`. This is simply to assist in visual
+The primary difference between modern (ES6) JavaScript and Reason lambdas is that
+Reason lambdas begin with the word `fun`. This is simply to assist in visual
 understanding of the meaning of a function when it has a very large destructured
 argument.
 
@@ -114,7 +114,7 @@ JavaScript                        |   Reason
 <pre>const y = add(3, add(0, 1));</pre>    |  <pre>let y = add 3 (add 0 1);</pre>
 
 
-Like `JavaScript`, `Reason` allows any expression on the right hand side of the
+Like JavaScript, Reason allows any expression on the right hand side of the
 lambda `=>`.
 
 <table>
@@ -136,9 +136,9 @@ let add = fun (x, y) =>
 </table>
 
 
-However, `JavaScript` allows lambdas to return `{}` blocks *instead* of expressions, by way of a `return`
-statement wrapped in `{}` braces. With `Reason`, `{}` blocks are *already* expressions, so `Reason` doesn't
-require two modes for lambda - all lambdas in `Reason` have expressions on the right hand side of the `=>`,
+However, JavaScript allows lambdas to return `{}` blocks *instead* of expressions, by way of a `return`
+statement wrapped in `{}` braces. With Reason, `{}` blocks are *already* expressions, so Reason doesn't
+require two modes for lambda - all lambdas in Reason have expressions on the right hand side of the `=>`,
 and some of those expressions coincidentally resemble "function bodies" in `{}` braces.
 
 <table>
@@ -164,12 +164,12 @@ let myFun = fun (x, y) => {
 </table>
 
 
-When using `Reason` every function accepts a single argument. In this example,
+When using Reason every function accepts a single argument. In this example,
 that single argument happens to be a destructured tuple. This appears very
-similar to the `JavaScript` arguments. However, the difference is apparent
-when supplying those arguments as first class. In `JavaScript`, arguments
+similar to the JavaScript arguments. However, the difference is apparent
+when supplying those arguments as first class. In JavaScript, arguments
 are an array, and supplying *all* of the arguments requires `.apply`.
-In `Reason`, you may simply supply the tuple.
+In Reason, you may simply supply the tuple.
 
 <table>
   <thead><tr> <th scope="col"><p >JavaScript</p></th> <th scope="col"><p>Reason</p></th></tr></thead>
@@ -195,9 +195,9 @@ let result = add myArgs;</pre>
 
 ### Function Application
 
-In `Reason`, parentheses are typically optional in places where it is obvious
+In Reason, parentheses are typically optional in places where it is obvious
 they aren't needed. This means that when invoking functions, parentheses
-aren't always required around the argument. `Reason` will let you add the
+aren't always required around the argument. Reason will let you add the
 parentheses if you really want them, but it's good to know why some samples
 you read have omitted them. See how in this example, arguments that are clearly
 single words, or that have balanced "bookends" (such as `{ }`) do not need
@@ -231,11 +231,11 @@ let result = aFunc {x:0};</pre>
 
 ### Currying
 
-Both `JavaScript` and `Reason` support currying, but with `Reason`, when using
-the native compiler (or even a `JavaScript` backend), currying is optimized.
-(Specifically, you are not penalized for currying in `Reason`, whenever you
+Both JavaScript and Reason support currying, but with Reason, when using
+the native compiler (or even a JavaScript backend), currying is optimized.
+(Specifically, you are not penalized for currying in Reason, whenever you
 happen to supply all the arguments). The main syntactic difference when defining
-curried functions is that `Reason` lambdas always begin with the `fun` keyword.
+curried functions is that Reason lambdas always begin with the `fun` keyword.
 
 <table>
   <thead><tr> <th scope="col"><p >JavaScript</p></th> <th scope="col"><p>Reason</p></th></tr></thead>
@@ -245,7 +245,7 @@ curried functions is that `Reason` lambdas always begin with the `fun` keyword.
   </tr>
 </table>
 
-When invoking curried functions, the syntax is the same, but with `Reason`,
+When invoking curried functions, the syntax is the same, but with Reason,
 supplying the parenthesis is optional.
 
 <table>
@@ -268,8 +268,8 @@ supplying the parenthesis is optional.
   </tr>
 </table>
 
-Because `Reason` lambdas include the `fun` keyword, curried functions don't
-appear as clean as they do in `JavaScript`. To remedy this, `Reason` includes a
+Because Reason lambdas include the `fun` keyword, curried functions don't
+appear as clean as they do in JavaScript. To remedy this, Reason includes a
 syntactic sugar to help with curried function definitions. The two forms
 are *exactly* equivalent and nothing changes about how you would invoke these
 functions.
@@ -297,7 +297,7 @@ functions.
 
 ### Record Fields
 
-In `Reason`, you must ensure your record literal has an unambiguous type if you
+In Reason, you must ensure your record literal has an unambiguous type if you
 want to create records or access record fields. In the simplest case, the record
 type is already in scope and you can unambiguously create values just by using
 the standard `{ key: value }` syntax.
@@ -386,10 +386,10 @@ let bob = {
 ### Expressions
 
 If it wasn't already clear, in Reason, almost everything is an expression. For
-example, in `Reason`, the `switch` statement *evaluates* to a value, which makes
-programming less error prone. Notice how in the `JavaScript` version, there is
+example, in Reason, the `switch` statement *evaluates* to a value, which makes
+programming less error prone. Notice how in the JavaScript version, there is
 some time when the program is in an invalid state.  The switch statement in
-`Reason` also provides many more super powers, discussed in [Pattern
+Reason also provides many more super powers, discussed in [Pattern
 Matching](./index.html#diving-deeper-expressive-pattern-matching).
 
 <table>

--- a/src/pages/guide/language/index.md
+++ b/src/pages/guide/language/index.md
@@ -15,11 +15,11 @@ Reason is an umbrella project that provides a curated layer for [OCaml](http://o
 
 #### Worry-free
 
-Reason leverages OCaml's language design and type system to give immediate feedback in the form of compile-time errors and avoided anti-patterns.
+Reason leverages OCaml's language design and type system to give immediate feedback in the form of compile-time errors and language features that make it easy to avoid anti-patterns.
 
 #### Low Overhead
 
-Reason keeps things simple and lean. Thanks to this, integrating Reason into your existing JavaScript/OCaml project is [hassle-free](./gettingStarted.html#javascript-workflow). Do more with less; reduce your future burden!
+Reason keeps things simple and lean. Thanks to this, integrating Reason into your existing [JavaScript](./getting-starded.md#javascript-workflow) or [OCaml](./getting-starded.md#native-workflow) project is hassle-free. Do more with less; reduce your future burden!
 
 #### Performant & predictable
 
@@ -29,26 +29,24 @@ How Reason Works
 =========================
 
 The OCaml compiler is organized into several stages, which are exposed as
-libraries. `Reason` replaces part of the compiler toolchain with a completely
+libraries. Reason replaces part of the compiler toolchain with a completely
 new syntax parser that is more approachable, while still fully compatible with
-the rest of the compiler.  `Reason` also implements a new source printer which
+the rest of the compiler.  Reason also implements a new source printer which
 integrates into your IDE and the new custom [`REPL`](./tools.html#repl).
 
 ###### Why OCaml?
 
-OCaml is a great tool for writing highly expressive, functional
+OCaml is a great language for writing highly expressive, functional
 *or* imperative code, with type inference and fast runtime performance.
 Because of these properties, OCaml has helped
 Facebook quickly build scalable infrastructure such as
 [Hack](http://hacklang.org/), [Flow](http://flowtype.org/), and
 [Infer](http://fbinfer.com/). It is also used for other performance sensitive
-applications in the financial industry (Jane Street, Bloomberg). At the same
-time, OCaml has a very mature (*and still growing*) ecosystem for targeting
-browser and `JavaScript` environments with a focus on language interoperability
-and integration with existing `JavaScript` code.
+applications in the financial industry (Jane Street, Bloomberg).
 
-
-`Reason`'s non-invasive approach to the `OCaml` compiler allows `Reason` code
-to take advantage of all of the existing `OCaml` compiler
-optimizations/backends such as bare metal `ARM`, `x86`, and even `JavaScript`
-compilation.
+Reason's non-invasive approach to the OCaml compiler allows Reason code
+to take advantage of all of the existing OCaml compiler
+optimizations/backends such as bare metal ARM, x86, and even JavaScript
+compilation. OCaml has a very mature (*and still growing*) ecosystem for targeting
+browser and JavaScript environments with a focus on language interoperability
+and integration with existing JavaScript code.

--- a/src/pages/guide/native/convert-from-ocaml.md
+++ b/src/pages/guide/native/convert-from-ocaml.md
@@ -3,11 +3,11 @@ title: Converting from OCaml
 order: 4
 ---
 
-Since Reason's just another syntax for OCaml, convert an OCaml project over is straightforward and doesn't require semantic changes. However, there are a few build setup & miscellaneous changes.
+Since Reason is just another syntax for OCaml, converting an OCaml project over is straightforward and doesn't require semantic changes. However, there are a few build setup and miscellaneous changes required.
 
 #### OCamlBuild -> Rebuild
 Reason comes with a drop in replacement for `ocamlbuild` called `rebuild`, that
-will automatically build any reason file along with your OCaml files, with
+will automatically build any Reason file along with your OCaml files, with
 no additional configuration. This allows you to add Reason files to your existing
 OCaml project bit by bit. Wherever your script refers to `ocamlbuild`, just replace
 it with `rebuild`.

--- a/src/pages/guide/native/index.md
+++ b/src/pages/guide/native/index.md
@@ -3,7 +3,7 @@ title: Native
 order: 5
 ---
 
-We currently use the default OCaml workflow to compile to native, although [there's work underway](https://github.com/bsansouci/bsb-native) to bring native compilation support to the bucklescript builder.
+We currently use the default OCaml workflow to compile to native, although [there's work underway](https://github.com/bsansouci/bsb-native) to bring native compilation support to the BuckleScript builder.
 
 > **Note**: some parts of the native workflow likely don't work on Windows. The native workflow is currently **work in progress**, as we're currently focusing on polishing the JS workflow. Contribution welcome!
 

--- a/src/pages/guide/ocaml.md
+++ b/src/pages/guide/ocaml.md
@@ -6,7 +6,7 @@ order: 10
 A quick reference for OCaml programmers.
 
 Consult the general [Syntax Basics](index.html#syntax-basics) for an overview
-of the `Reason` syntax. This guide merely dives deeper into the differences and
+of the Reason syntax. This guide merely dives deeper into the differences and
 improvements that OCaml programmers would notice most.
 
 ### Comments
@@ -34,8 +34,8 @@ Reason will also *eventually* support line comments, which are not supported in 
 
 ###REPL ([Read-Eval-Print-Loop](https://en.wikipedia.org/wiki/Read–eval–print_loop))
 
-In `Reason`'s repl `rtop` (a customized `utop`), each input is submitted via
-a single `;` semicolon. `OCaml`'s repl requires two semicolons `;;`.
+In Reason's repl `rtop` (a customized `utop`), each input is submitted via
+a single `;` semicolon. OCaml's repl requires two semicolons `;;`.
 
 <table>
   <thead><tr> <th scope="col"><p >OCaml REPL</p></th> <th scope="col"><p>Reason REPL</p></th></tr></thead>
@@ -51,14 +51,14 @@ a single `;` semicolon. `OCaml`'s repl requires two semicolons `;;`.
 
 ###Operator Renaming
 
-`Reason` has all of `OCaml`'s infix operators, but a couple of operators
+Reason has all of OCaml's infix operators, but a couple of operators
 are *expressed* differently.
-In `Reason`, structural equality is written as `==`, and reference equality
+In Reason, structural equality is written as `==`, and reference equality
 (physical equality)
-is written as `===` (so just remember to add an extra `=` to what `OCaml`
-requires). In `Reason`, to achieve the corresponding *inequality*,
+is written as `===` (so just remember to add an extra `=` to what OCaml
+requires). In Reason, to achieve the corresponding *inequality*,
 simply swap the first character with a `!` character. (`!=` for structural
-inequality, and `!==` for reference inequality). `Reason`'s
+inequality, and `!==` for reference inequality). Reason's
 symbol choices are slightly more consistent and follow the ES6 conventions.
 <table>
   <thead><tr><th scope="col"><p>Equality</p></th> <th scope="col"><p>Expressed in OCaml via</p></th> <th scope="col"><p>Expressed in Reason via</p></th></tr></thead>
@@ -124,9 +124,9 @@ x !== y</pre>
 
 ### Local Scope
 
-`Reason`'s lexical scoping is exactly the same as `OCaml`'s, but let bindings
+Reason's lexical scoping is exactly the same as OCaml's, but let bindings
 syntactically resemble "block scope" which is more familiar to many
-developers. In `Reason`, they are created with `{}` braces, which
+developers. In Reason, they are created with `{}` braces, which
 may contain both `let` bindings and imperative commands, separated by `;`.
 All blocks *evaluate* to the last line and the semicolon on the last line is
 optional. `{}` braces are only needed if you have more than one item to chain
@@ -155,7 +155,7 @@ let \_ =
   </tr>
 </table>
 
-`Reason`'s `{}` syntax removes many commonly reported pain points in `OCaml`'s
+Reason's `{}` syntax removes many commonly reported pain points in OCaml's
 syntax:
 
 - Double semicolons are removed entirely.
@@ -165,12 +165,12 @@ syntax:
 
 ### Local Scope Vs. Module Bodies
 
-In `Reason`, everything that can go between the `{}` in [Local
+In Reason, everything that can go between the `{}` in [Local
 Scopes](#reason-vs-ml-syntax-local-scope) and in module bodies. You can usually
-even cut/paste code between the two contexts. In `OCaml`, the syntaxes for the two
+even cut/paste code between the two contexts. In OCaml, the syntaxes for the two
 contexts are very different. (Local scope requires trailing `in`, but module bodies do
 not and some imperative statements must be assigned to `_` or `()`, or else use double `;;`).
-`Reason` greatly simplifies the syntax for new _and_ experienced ML programmers.
+Reason greatly simplifies the syntax for new _and_ experienced ML programmers.
 
 <table>
   <thead><tr> <th scope="col"><p>OCaml Module Body</p></th><th scope="col"><p>Reason Module Body</p></th></tr></thead>
@@ -237,7 +237,7 @@ let ten = 10 in (
 
 ### Tuples and Records
 
-In `Reason`, tuples always require parentheses. This requirement makes `Reason` easier to
+In Reason, tuples always require parentheses. This requirement makes Reason easier to
 read and also removes the need for type annotations inside of tuple members
 to be wrapped in *additional* parentheses.
 <table>
@@ -268,8 +268,8 @@ to be wrapped in *additional* parentheses.
   </tr>
 </table>
 
-In `Reason`, records resemble JavaScript, using `:` instead of `=`. Because
-`Reason` tuples always require wrapping parens, records may contain lambdas as values
+In Reason, records resemble JavaScript, using `:` instead of `=`. Because
+Reason tuples always require wrapping parens, records may contain lambdas as values
 without needing extra parens.
 <table>
   <thead><tr> <th scope="col"><p>OCaml</p></th><th scope="col"><p>Reason</p></th></tr></thead>
@@ -302,7 +302,7 @@ let myFuncs = {
 
 ### Lists
 
-Lists in `Reason` are delimited with commas rather than semi-colons as they are in JavaScript. `Reason` also uses JavaScript's spread syntax for list concatenation instead of the `::` operator.
+Lists in Reason are delimited with commas rather than semi-colons as they are in JavaScript. Reason also uses JavaScript's spread syntax for list concatenation instead of the `::` operator.
 
 <table>
 <thead><tr> <th scope="col"><p>OCaml Lists</p></th><th scope="col"><p>Reason Lists</p></th></tr></thead>
@@ -320,8 +320,8 @@ Lists in `Reason` are delimited with commas rather than semi-colons as they are 
 
 ### Type Definitions
 
-With `Reason`, types generally look like the values they represent.  There is
-only one syntactic pattern to learn for each kind of type. Whereas in `OCaml`,
+With Reason, types generally look like the values they represent.  There is
+only one syntactic pattern to learn for each kind of type. Whereas in OCaml,
 there are separate syntaxes for tuple types `(x * y)` and tuple values
 `(x, y)`).
 
@@ -371,29 +371,29 @@ let x: func = fun a => a + 1;</pre>
 
 ### Functions
 
-`OCaml` has three ways to define functions:
+OCaml has three ways to define functions:
 
-- Some `OCaml` forms use arrows `->`, some use equals `=`.
-- Some `OCaml` forms use the `fun` keyword, others use the `function` keyword.
+- Some OCaml forms use arrows `->`, some use equals `=`.
+- Some OCaml forms use the `fun` keyword, others use the `function` keyword.
 
-`Reason` also supports the same three ways to define lambdas, but for
+Reason also supports the same three ways to define lambdas, but for
 consistency:
 
-- Every `Reason` form uses an `=>` arrow in one way or another.\*
-- `Reason` uses at most one keyword (`fun`).
+- Every Reason form uses an `=>` arrow in one way or another.\*
+- Reason uses at most one keyword (`fun`).
 - As with all pattern matching, the leading bar `|` is required in the single
   argument pattern match form.
 
 ###### Single argument match functions
 
-`OCaml` has a function definition (`function |`) which is considered to be
-equivalent of `function a -> match a with ...`. `Reason` has the same, but
+OCaml has a function definition (`function |`) which is considered to be
+equivalent of `function a -> match a with ...`. Reason has the same, but
 the syntax makes it clear how it is actually an extension of a single argument
 function. The single case match is a natural extension of the simple lambda,
 and the multicase lambda is a natural extension of the single case lambda.
 
 <table>
-  <thead><tr> <th scope="col"><p>Form</p></th><th scope="col"><p>Ocaml</p></th><th scope="col"><p>Reason</p></th></tr></thead>
+  <thead><tr> <th scope="col"><p>Form</p></th><th scope="col"><p>OCaml</p></th><th scope="col"><p>Reason</p></th></tr></thead>
   <tr>
     <td>
       lambda
@@ -439,11 +439,11 @@ fun | pat => e
 
 ###### Let binding for curried functions
 
-Both `OCaml` and `Reason` syntax offer a syntactic sugar for expressing curried
+Both OCaml and Reason syntax offer a syntactic sugar for expressing curried
 functions. The following table shows three equivalent definitions which are
-identical once parsed. As always, all `Reason` functions include an `=>` arrow.
+identical once parsed. As always, all Reason functions include an `=>` arrow.
 
-<table> <thead><tr><th scope="col"><p>Ocaml</p></th><th
+<table> <thead><tr><th scope="col"><p>OCaml</p></th><th
         scope="col"><p>Reason</p></th></tr></thead>
   <tr>
     <td>
@@ -480,7 +480,7 @@ let x a b => e;</pre>
 
 ### Annotating Function Arguments
 
-In both `Reason` and `OCaml`, arguments are annotated with types by (as with
+In both Reason and OCaml, arguments are annotated with types by (as with
 everything else), wrapping them in parenthesis after appending
 `:typeAnnotation`.
 
@@ -498,7 +498,7 @@ fun (arg : argType) (arg2 : arg2Type) => returnValue;
 
 
 
-Both `Reason` and `OCaml` allow annotating the return type, when using the
+Both Reason and OCaml allow annotating the return type, when using the
 "super sugared let binding" form.
 
 ```ocaml
@@ -515,7 +515,7 @@ let myFunc (a:int) (b:int) :(int, int) => (a, b);
 let myFunc (a:int) (b:int) :list int => [1];
 let myFunc (a:int) (b:int) :(int => int) => fun x => x + a + b;
 ```
-> Because we're using `=>` for all functions everywhere in `Reason`, there's
+> Because we're using `=>` for all functions everywhere in Reason, there's
 one case where we need to add extra parens around a return type that is
 itself a function type.
 
@@ -596,9 +596,9 @@ let tuples: pairs = [(2, 3)]</pre>
 
 ### Tuples as Type Parameters
 
-Because `OCaml` uses parens and commas to represent multiple arguments to type
+Because OCaml uses parens and commas to represent multiple arguments to type
 constructors, it's confusing when one of the arguments to a type constructor is
-itself a tuple. In `OCaml`, it's difficult to remember the difference between a
+itself a tuple. In OCaml, it's difficult to remember the difference between a
 type constructor accepting multiple arguments and a type constructor accepting
 a single argument which happens to be a tuple.
 
@@ -620,9 +620,9 @@ type pairList = list (int, int);</pre>
   </tr>
 </table>
 
-- In `Reason`, syntax that represent tuple or tuple types, always looks like
+- In Reason, syntax that represent tuple or tuple types, always looks like
   tuples.
-- In `Reason`, syntax that represent records or record types, always look like
+- In Reason, syntax that represent records or record types, always look like
   records.
 - Just about everything else uses the syntactic pattern of function application
   (space separated arguments).
@@ -632,7 +632,7 @@ type pairList = list (int, int);</pre>
 ### Variants
 
 ###### OCaml
-- `OCaml` already expects constructor argument types to be specified in tuple
+- OCaml already expects constructor argument types to be specified in tuple
   form, so it's confusing when a single constructor expects a single argument
   that *happens* to be a tuple type.
 - What's even more confusing is that the constructors don't *actually* accept
@@ -730,10 +730,10 @@ let res = switch x {
   possibilities in the grammar without conflicts.
 
 
-Can you spot the error in the `OCaml` example? This is one of the most common
-mistakes among `OCaml` programmers. The second `match` *must* be wrapped in
+Can you spot the error in the OCaml example? This is one of the most common
+mistakes among OCaml programmers. The second `match` *must* be wrapped in
 parentheses, otherwise the `Some` case is parsed as belonging to the outer
-`match`. `Reason`'s required `{}` blocks around match cases prevent this
+`match`. Reason's required `{}` blocks around match cases prevent this
 issue.
 
 <table>
@@ -808,9 +808,9 @@ module MyModule = {
 ##### Functors Types
 
 In the same way that type parameters (think generics) were made consistent with
-function application syntax, `Reason` also unifies the syntax for Functors.
+function application syntax, Reason also unifies the syntax for Functors.
 
-In `Reason`, functor parsing rules are almost identical to the function
+In Reason, functor parsing rules are almost identical to the function
   parsing rules, using `=>` to represent curried application.
 
 <table>
@@ -835,7 +835,7 @@ module type FType =
 
 ### Functors
 
-In `Reason`, the syntax for creating and applying functors is nearly identical
+In Reason, the syntax for creating and applying functors is nearly identical
 to the syntax for creating/applying functions. Also, functor *application* is
 consistent with function application (again, space separated lists).
 
@@ -911,14 +911,14 @@ conform to function application syntax when in type annotation position - see
 
 OCaml doesn't require parens around sequences `(a;b;c;d)` or tuples `(x,y)`, so
 that ends up ruling out a bunch of other very convenient syntax rules.  Since
-Reason always uses `{}` to enclose sequences or let bindings, and `Reason`
+Reason always uses `{}` to enclose sequences or let bindings, and Reason
 always requires `()` around tuples, many other syntax constructs are expressed
 more intuitively, without requiring extra wrapping in parenthesis.
 
 
 ###### Lambdas as record fields no longer need extra parens
 
-This is a welcomed improvement because the `OCaml` type errors the user would
+This is a welcomed improvement because the OCaml type errors the user would
 see were very confusing when it would believe the function's return value
 was a tuple with infix `,` comma.
 
@@ -995,7 +995,7 @@ let tuple =
 
 #####`as` precedence
 
-With `Reason`, `as` has a higher precedence than `|` bar. This allows creating `as` aliases
+With Reason, `as` has a higher precedence than `|` bar. This allows creating `as` aliases
 for entire rows in pattern matching.
 
 <table>
@@ -1033,7 +1033,7 @@ let | MyThing \_ as ppp
 
 ###Mutable Record Field Updates
 
-Because equalities and their negations have been made more consistent in `Reason`,
+Because equalities and their negations have been made more consistent in Reason,
 the `=` operator is available for mutable field update.
 <table>
   <thead><tr> <th scope="col"><p >OCaml</p></th> <th scope="col"><p>Reason</p></th></tr></thead>
@@ -1055,7 +1055,7 @@ In Reason, `!` and other prefix operators have lower precedence than dot `.` or 
 This is more consistent with what other languages do, and is more practical
 when (or if) the `!` symbol is used to represent boolean `not`.
 
-Ocaml                                 | Reason
+OCaml                                 | Reason
 --------------------------------------|--------------------------------
 <pre>   let x = !(foo.bar);    </pre> | <pre>    let x = !foo.bar;        </pre>
 <pre>   let x = !(foo#bar);    </pre> | <pre>    let x = !foo#bar;        </pre>
@@ -1093,9 +1093,9 @@ OCaml                                        | Reason
 
 
 ###### Operator Renaming
-If `Reason` uses `==` to represent `OCaml`'s `=`, and
-uses `===` to represent `OCaml`'s `==`, then how would `Reason` represent `OCaml`'s
-`===` symbol (if it were defined)? `Reason` provides a way! "Escape" the triple
+If Reason uses `==` to represent OCaml's `=`, and
+uses `===` to represent OCaml's `==`, then how would Reason represent OCaml's
+`===` symbol (if it were defined)? Reason provides a way! "Escape" the triple
 equals symbol!
 
 <table>


### PR DESCRIPTION
This PR does two main things:

* Removes backticks around proper nouns like OCaml, Reason, and JavaScript. This was being used inconsistently, and typically proper nouns aren't formatted this way, so I just removed it.

* Updates content in a few sections to improve clarity (will comment on each section to point them out)