### PR TITLE
Decrease font and logo sizes for small mobile devices

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -54,13 +54,13 @@ export default class Index extends React.Component {
         <Section backgroundColor={gray}>
           <Header />
           <div css={{ alignItems: 'center' }}>
-            <img src={logo} width={300} height={112} />
+            <img src={logo} css={styles.logo} />
             <p css={styles.description}>
               Reason is a new syntax and toolchain for OCaml, a powerful
               language that will give you type-safe, maintainable code that
               transforms into performant, readable JavaScript.
             </p>
-            <div css={{ flexDirection: 'row', marginBottom: '1.5em' }}>
+            <div css={styles.buttonGroup}>
               <Link to="/guide/getting-started/" css={styles.button}>
                 Get started
               </Link>
@@ -150,10 +150,15 @@ const styles = {
   description: {
     maxWidth: 600,
     fontWeight: 200,
-    fontSize: '1.5em',
+    fontSize: '1.1em',
     lineHeight: '1.5em',
     textAlign: 'center',
     textShadow: '1px 1px white',
+    padding: '0.8em',
+    marginBottom: 0,
+    '@media(min-width: 800px)': {
+      fontSize: '1.5em'
+    }
   },
   content: {
     maxWidth: 1270,
@@ -169,7 +174,18 @@ const styles = {
     padding: '8px 34px',
     borderRadius: 5,
     margin: 10,
+    textAlign: 'center'
   },
+
+  buttonGroup: {
+    flexDirection: 'row',
+    marginBottom: '1.5em',
+    '@media(max-width: 340px)': {
+      flexDirection: 'column',
+      width: '80%'
+    }
+  },
+
   featuresDivider: {
     height: 1,
     backgroundColor: '#cecece',
@@ -183,4 +199,9 @@ const styles = {
     backgroundColor: 'white',
     padding: 30,
   },
+
+  logo: {
+    maxWidth: 300,
+    width: '80%'
+  }
 }


### PR DESCRIPTION
Fixes some formatting issues on the home page for small mobile devices (iPhone 5, for example)

Changes can be previewed here: http://mobile-content-size-reasonml.surge.sh/


# Before

<img width="344" alt="screen shot 2017-07-16 at 1 41 26 pm" src="https://user-images.githubusercontent.com/6886061/28250388-9451fc66-6a2c-11e7-9218-965957024c4c.png">


# After

<img width="344" alt="screen shot 2017-07-16 at 1 41 17 pm" src="https://user-images.githubusercontent.com/6886061/28250390-99aa2fc6-6a2c-11e7-9a83-e3cc06a50d32.png">
