### PR TITLE
Move markdown comment outside of verbatim block

### DIFF
--- a/src/pages/guide/language/types.md
+++ b/src/pages/guide/language/types.md
@@ -18,8 +18,11 @@ let myInt = 5;
 let myInt = (5 : int);
 let myInt = (5 : int) + (4 : int);
 let add (x: int) (y: int) :int => x + y;
-let drawCircle radius::(r: int) :unit => ...; /* radius::(r: int) is a labeled argument. More on this [here](https://reasonml.github.io/guide/language/functions) */
+let drawCircle radius::(r: int) :unit => ...;
 ```
+
+Note: in the last line, `radius::(r: int)` is a labeled argument.
+More on this [here](https://reasonml.github.io/guide/language/functions).
 
 #### Type Aliases
 


### PR DESCRIPTION
The markdown hyperlink inside the code comment wasn't rendering into an actual hyperlink, so I moved it outside of the verbatim block into a body paragraph.