### PR TITLE
Styling fixes for API docs

### DIFF
--- a/src/templates/API.js
+++ b/src/templates/API.js
@@ -36,7 +36,7 @@ export default class API extends Component {
         </Section>
         <div css={{alignItems: 'center'}}>
           <div 
-            css={{maxWidth: 1270}}
+            css={{maxWidth: 1270, width: '100%'}}
             dangerouslySetInnerHTML={{__html: content}}
           />
         </div>

--- a/src/templates/API.js
+++ b/src/templates/API.js
@@ -27,7 +27,7 @@ export default class API extends Component {
             </h1>
           </div>
         </Section>
-        <Section css={{paddingTop: '36px'}}>
+        <Section css={{padding: '36px 24px 0'}}>
           <h2>Standard Library</h2>
           <p css={{maxWidth: 1270}}>
             Below is the API for the OCaml standard library. It's directly copied over from <a href="http://caml.inria.fr/pub/docs/manual-ocaml/libref/index.html">the OCaml Manual</a>, formatted to the Reason syntax and styled accordingly.

--- a/src/templates/api.css
+++ b/src/templates/api.css
@@ -66,6 +66,7 @@
 }
 .ocamldoc .typetable {
   border-style: hidden;
+  width: auto;
 }
 .ocamldoc .paramstable {
   border-style: hidden;
@@ -199,13 +200,6 @@
 .ocamldoc .info-desc {
   margin-bottom: 1em;
 }
-/*.ocamldoc div.info > p:first-child {
-  margin-top: 0;
-}
-.ocamldoc div.info-desc > p:first-child {
-  margin-top: 0;
-  margin-bottom: 0;
-}*/
 .ocamldoc hr {
   border: none;
   border-bottom: 1px solid #aaa;


### PR DESCRIPTION
Fixes #29 

Fix rendering of union types
<img width="922" alt="screen shot 2017-07-17 at 9 46 37 pm" src="https://user-images.githubusercontent.com/1232587/28301515-fc73d3ae-6b3b-11e7-8423-45e8a90da37b.png">

Fix for narrow window size (side padding)
<img width="890" alt="screen shot 2017-07-17 at 9 47 53 pm" src="https://user-images.githubusercontent.com/1232587/28301519-08e3f6e6-6b3c-11e7-8f89-e5f50e2acda3.png">
