### PR TITLE
fix rendering of API docs 'type' pages

### DIFF
--- a/generate-docs/transform.js
+++ b/generate-docs/transform.js
@@ -1,5 +1,6 @@
 const cheerio = require('cheerio');
 const spawn = require('child_process').spawnSync;
+const path = require('path');
 
 function convert(input, isInterface) {
   const result = spawn(
@@ -29,6 +30,14 @@ module.exports = function(fileInfo, api, options) {
       return $el.text($el.text().replace('OCaml library', 'Reason API'));
     });
     $('br').remove();
+  }
+
+  if (path.basename(fileInfo.path).startsWith('type_')) {
+    // turn module interface page into <pre> so code whitespace is preserved
+    const typePageContent = $('code');
+    typePageContent
+      .parent()
+      .html(`<pre>${typePageContent.html().replace('<br>', '\n')}</pre>`);
   }
 
   $('title').map((i, el) => {

--- a/src/pages/api/type_Arg.html
+++ b/src/pages/api/type_Arg.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;spec&#xA0;=
 &#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;Unit&#xA0;of&#xA0;(unit&#xA0;-&gt;&#xA0;unit)
 &#xA0;&#xA0;&#xA0;&#xA0;|&#xA0;Bool&#xA0;of&#xA0;(bool&#xA0;-&gt;&#xA0;unit)
@@ -44,4 +44,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;(Arg.key&#xA0;*&#xA0;Arg.spec&#xA0;*&#xA0;Arg.doc)&#xA0;list&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;(Arg.key&#xA0;*&#xA0;Arg.spec&#xA0;*&#xA0;Arg.doc)&#xA0;list
 &#xA0;&#xA0;val&#xA0;current&#xA0;:&#xA0;int&#xA0;Pervasives.ref
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Array.html
+++ b/src/pages/api/type_Array.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;external&#xA0;length&#xA0;:&#xA0;&apos;a&#xA0;array&#xA0;-&gt;&#xA0;int&#xA0;=&#xA0;&quot;%array_length&quot;
 &#xA0;&#xA0;external&#xA0;get&#xA0;:&#xA0;&apos;a&#xA0;array&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;&apos;a&#xA0;=&#xA0;&quot;%array_safe_get&quot;
 &#xA0;&#xA0;external&#xA0;set&#xA0;:&#xA0;&apos;a&#xA0;array&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;unit&#xA0;=&#xA0;&quot;%array_safe_set&quot;
@@ -28,4 +28,4 @@
 &#xA0;&#xA0;val&#xA0;fast_sort&#xA0;:&#xA0;(&apos;a&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;int)&#xA0;-&gt;&#xA0;&apos;a&#xA0;array&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;external&#xA0;unsafe_get&#xA0;:&#xA0;&apos;a&#xA0;array&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;&apos;a&#xA0;=&#xA0;&quot;%array_unsafe_get&quot;
 &#xA0;&#xA0;external&#xA0;unsafe_set&#xA0;:&#xA0;&apos;a&#xA0;array&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;unit&#xA0;=&#xA0;&quot;%array_unsafe_set&quot;
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_ArrayLabels.html
+++ b/src/pages/api/type_ArrayLabels.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;external&#xA0;length&#xA0;:&#xA0;&apos;a&#xA0;array&#xA0;-&gt;&#xA0;int&#xA0;=&#xA0;&quot;%array_length&quot;
 &#xA0;&#xA0;external&#xA0;get&#xA0;:&#xA0;&apos;a&#xA0;array&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;&apos;a&#xA0;=&#xA0;&quot;%array_safe_get&quot;
 &#xA0;&#xA0;external&#xA0;set&#xA0;:&#xA0;&apos;a&#xA0;array&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;unit&#xA0;=&#xA0;&quot;%array_safe_set&quot;
@@ -29,4 +29,4 @@
 &#xA0;&#xA0;val&#xA0;fast_sort&#xA0;:&#xA0;cmp:(&apos;a&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;int)&#xA0;-&gt;&#xA0;&apos;a&#xA0;array&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;external&#xA0;unsafe_get&#xA0;:&#xA0;&apos;a&#xA0;array&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;&apos;a&#xA0;=&#xA0;&quot;%array_unsafe_get&quot;
 &#xA0;&#xA0;external&#xA0;unsafe_set&#xA0;:&#xA0;&apos;a&#xA0;array&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;unit&#xA0;=&#xA0;&quot;%array_unsafe_set&quot;
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Ast_helper.Cf.html
+++ b/src/pages/api/type_Ast_helper.Cf.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;mk&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;?loc:Ast_helper.loc&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?attrs:Ast_helper.attrs&#xA0;-&gt;
@@ -41,4 +41,4 @@
 &#xA0;&#xA0;val&#xA0;concrete&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;Asttypes.override_flag&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;Parsetree.expression&#xA0;-&gt;&#xA0;Parsetree.class_field_kind
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Ast_helper.Ci.html
+++ b/src/pages/api/type_Ast_helper.Ci.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;mk&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;?loc:Ast_helper.loc&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?attrs:Ast_helper.attrs&#xA0;-&gt;
@@ -8,4 +8,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;?virt:Asttypes.virtual_flag&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?params:(Parsetree.core_type&#xA0;*&#xA0;Asttypes.variance)&#xA0;list&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;Ast_helper.str&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;&apos;a&#xA0;Parsetree.class_infos
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Ast_helper.Cl.html
+++ b/src/pages/api/type_Ast_helper.Cl.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;mk&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;?loc:Ast_helper.loc&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?attrs:Ast_helper.attrs&#xA0;-&gt;
@@ -38,4 +38,4 @@
 &#xA0;&#xA0;val&#xA0;extension&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;?loc:Ast_helper.loc&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?attrs:Ast_helper.attrs&#xA0;-&gt;&#xA0;Parsetree.extension&#xA0;-&gt;&#xA0;Parsetree.class_expr
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Ast_helper.Csig.html
+++ b/src/pages/api/type_Ast_helper.Csig.html
@@ -1,6 +1,6 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;mk&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;Parsetree.core_type&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;Parsetree.class_type_field&#xA0;list&#xA0;-&gt;&#xA0;Parsetree.class_signature
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Ast_helper.Cstr.html
+++ b/src/pages/api/type_Ast_helper.Cstr.html
@@ -1,6 +1,6 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;mk&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;Parsetree.pattern&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;Parsetree.class_field&#xA0;list&#xA0;-&gt;&#xA0;Parsetree.class_structure
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Ast_helper.Ctf.html
+++ b/src/pages/api/type_Ast_helper.Ctf.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;mk&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;?loc:Ast_helper.loc&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?attrs:Ast_helper.attrs&#xA0;-&gt;
@@ -37,4 +37,4 @@
 &#xA0;&#xA0;val&#xA0;attribute&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;?loc:Ast_helper.loc&#xA0;-&gt;&#xA0;Parsetree.attribute&#xA0;-&gt;&#xA0;Parsetree.class_type_field
 &#xA0;&#xA0;val&#xA0;text&#xA0;:&#xA0;Docstrings.text&#xA0;-&gt;&#xA0;Parsetree.class_type_field&#xA0;list
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Ast_helper.Cty.html
+++ b/src/pages/api/type_Ast_helper.Cty.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;mk&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;?loc:Ast_helper.loc&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?attrs:Ast_helper.attrs&#xA0;-&gt;
@@ -22,4 +22,4 @@
 &#xA0;&#xA0;val&#xA0;extension&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;?loc:Ast_helper.loc&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?attrs:Ast_helper.attrs&#xA0;-&gt;&#xA0;Parsetree.extension&#xA0;-&gt;&#xA0;Parsetree.class_type
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Ast_helper.Exp.html
+++ b/src/pages/api/type_Ast_helper.Exp.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;mk&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;?loc:Ast_helper.loc&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?attrs:Ast_helper.attrs&#xA0;-&gt;
@@ -153,4 +153,4 @@
 &#xA0;&#xA0;val&#xA0;case&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;Parsetree.pattern&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?guard:Parsetree.expression&#xA0;-&gt;&#xA0;Parsetree.expression&#xA0;-&gt;&#xA0;Parsetree.case
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Ast_helper.Incl.html
+++ b/src/pages/api/type_Ast_helper.Incl.html
@@ -1,7 +1,7 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;mk&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;?loc:Ast_helper.loc&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?attrs:Ast_helper.attrs&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?docs:Docstrings.docs&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;&apos;a&#xA0;Parsetree.include_infos
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Ast_helper.Mb.html
+++ b/src/pages/api/type_Ast_helper.Mb.html
@@ -1,9 +1,9 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;mk&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;?loc:Ast_helper.loc&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?attrs:Ast_helper.attrs&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?docs:Docstrings.docs&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?text:Docstrings.text&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;Ast_helper.str&#xA0;-&gt;&#xA0;Parsetree.module_expr&#xA0;-&gt;&#xA0;Parsetree.module_binding
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Ast_helper.Md.html
+++ b/src/pages/api/type_Ast_helper.Md.html
@@ -1,9 +1,9 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;mk&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;?loc:Ast_helper.loc&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?attrs:Ast_helper.attrs&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?docs:Docstrings.docs&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?text:Docstrings.text&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;Ast_helper.str&#xA0;-&gt;&#xA0;Parsetree.module_type&#xA0;-&gt;&#xA0;Parsetree.module_declaration
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Ast_helper.Mod.html
+++ b/src/pages/api/type_Ast_helper.Mod.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;mk&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;?loc:Ast_helper.loc&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?attrs:Ast_helper.attrs&#xA0;-&gt;
@@ -32,4 +32,4 @@
 &#xA0;&#xA0;val&#xA0;extension&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;?loc:Ast_helper.loc&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?attrs:Ast_helper.attrs&#xA0;-&gt;&#xA0;Parsetree.extension&#xA0;-&gt;&#xA0;Parsetree.module_expr
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Ast_helper.Mtd.html
+++ b/src/pages/api/type_Ast_helper.Mtd.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;mk&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;?loc:Ast_helper.loc&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?attrs:Ast_helper.attrs&#xA0;-&gt;
@@ -7,4 +7,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;?text:Docstrings.text&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?typ:Parsetree.module_type&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;Ast_helper.str&#xA0;-&gt;&#xA0;Parsetree.module_type_declaration
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Ast_helper.Mty.html
+++ b/src/pages/api/type_Ast_helper.Mty.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;mk&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;?loc:Ast_helper.loc&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?attrs:Ast_helper.attrs&#xA0;-&gt;
@@ -32,4 +32,4 @@
 &#xA0;&#xA0;val&#xA0;extension&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;?loc:Ast_helper.loc&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?attrs:Ast_helper.attrs&#xA0;-&gt;&#xA0;Parsetree.extension&#xA0;-&gt;&#xA0;Parsetree.module_type
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Ast_helper.Opn.html
+++ b/src/pages/api/type_Ast_helper.Opn.html
@@ -1,9 +1,9 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;mk&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;?loc:Ast_helper.loc&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?attrs:Ast_helper.attrs&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?docs:Docstrings.docs&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?override:Asttypes.override_flag&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;Ast_helper.lid&#xA0;-&gt;&#xA0;Parsetree.open_description
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Ast_helper.Pat.html
+++ b/src/pages/api/type_Ast_helper.Pat.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;mk&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;?loc:Ast_helper.loc&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?attrs:Ast_helper.attrs&#xA0;-&gt;&#xA0;Parsetree.pattern_desc&#xA0;-&gt;&#xA0;Parsetree.pattern
@@ -63,4 +63,4 @@
 &#xA0;&#xA0;val&#xA0;extension&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;?loc:Ast_helper.loc&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?attrs:Ast_helper.attrs&#xA0;-&gt;&#xA0;Parsetree.extension&#xA0;-&gt;&#xA0;Parsetree.pattern
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Ast_helper.Sig.html
+++ b/src/pages/api/type_Ast_helper.Sig.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;mk&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;?loc:Ast_helper.loc&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;Parsetree.signature_item_desc&#xA0;-&gt;&#xA0;Parsetree.signature_item
@@ -43,4 +43,4 @@
 &#xA0;&#xA0;val&#xA0;attribute&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;?loc:Ast_helper.loc&#xA0;-&gt;&#xA0;Parsetree.attribute&#xA0;-&gt;&#xA0;Parsetree.signature_item
 &#xA0;&#xA0;val&#xA0;text&#xA0;:&#xA0;Docstrings.text&#xA0;-&gt;&#xA0;Parsetree.signature_item&#xA0;list
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Ast_helper.Str.html
+++ b/src/pages/api/type_Ast_helper.Str.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;mk&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;?loc:Ast_helper.loc&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;Parsetree.structure_item_desc&#xA0;-&gt;&#xA0;Parsetree.structure_item
@@ -51,4 +51,4 @@
 &#xA0;&#xA0;val&#xA0;attribute&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;?loc:Ast_helper.loc&#xA0;-&gt;&#xA0;Parsetree.attribute&#xA0;-&gt;&#xA0;Parsetree.structure_item
 &#xA0;&#xA0;val&#xA0;text&#xA0;:&#xA0;Docstrings.text&#xA0;-&gt;&#xA0;Parsetree.structure_item&#xA0;list
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Ast_helper.Te.html
+++ b/src/pages/api/type_Ast_helper.Te.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;mk&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;?attrs:Ast_helper.attrs&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?docs:Docstrings.docs&#xA0;-&gt;
@@ -28,4 +28,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;?docs:Docstrings.docs&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?info:Docstrings.info&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;Ast_helper.str&#xA0;-&gt;&#xA0;Ast_helper.lid&#xA0;-&gt;&#xA0;Parsetree.extension_constructor
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Ast_helper.Typ.html
+++ b/src/pages/api/type_Ast_helper.Typ.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;mk&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;?loc:Ast_helper.loc&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?attrs:Ast_helper.attrs&#xA0;-&gt;
@@ -56,4 +56,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;?loc:Ast_helper.loc&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?attrs:Ast_helper.attrs&#xA0;-&gt;&#xA0;Parsetree.extension&#xA0;-&gt;&#xA0;Parsetree.core_type
 &#xA0;&#xA0;val&#xA0;force_poly&#xA0;:&#xA0;Parsetree.core_type&#xA0;-&gt;&#xA0;Parsetree.core_type
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Ast_helper.Type.html
+++ b/src/pages/api/type_Ast_helper.Type.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;mk&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;?loc:Ast_helper.loc&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?attrs:Ast_helper.attrs&#xA0;-&gt;
@@ -24,4 +24,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;?info:Docstrings.info&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?mut:Asttypes.mutable_flag&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;Ast_helper.str&#xA0;-&gt;&#xA0;Parsetree.core_type&#xA0;-&gt;&#xA0;Parsetree.label_declaration
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Ast_helper.Val.html
+++ b/src/pages/api/type_Ast_helper.Val.html
@@ -1,9 +1,9 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;mk&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;?loc:Ast_helper.loc&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?attrs:Ast_helper.attrs&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?docs:Docstrings.docs&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?prim:string&#xA0;list&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;Ast_helper.str&#xA0;-&gt;&#xA0;Parsetree.core_type&#xA0;-&gt;&#xA0;Parsetree.value_description
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Ast_helper.Vb.html
+++ b/src/pages/api/type_Ast_helper.Vb.html
@@ -1,9 +1,9 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;mk&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;?loc:Ast_helper.loc&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?attrs:Ast_helper.attrs&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?docs:Docstrings.docs&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;?text:Docstrings.text&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;Parsetree.pattern&#xA0;-&gt;&#xA0;Parsetree.expression&#xA0;-&gt;&#xA0;Parsetree.value_binding
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Ast_helper.html
+++ b/src/pages/api/type_Ast_helper.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;lid&#xA0;=&#xA0;Longident.t&#xA0;Asttypes.loc
 &#xA0;&#xA0;type&#xA0;str&#xA0;=&#xA0;string&#xA0;Asttypes.loc
 &#xA0;&#xA0;type&#xA0;loc&#xA0;=&#xA0;Location.t
@@ -781,4 +781,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;Parsetree.pattern&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;Parsetree.class_field&#xA0;list&#xA0;-&gt;&#xA0;Parsetree.class_structure
 &#xA0;&#xA0;&#xA0;&#xA0;end
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Ast_mapper.html
+++ b/src/pages/api/type_Ast_mapper.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;mapper&#xA0;=&#xA0;{
 &#xA0;&#xA0;&#xA0;&#xA0;attribute&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;Ast_mapper.mapper&#xA0;-&gt;&#xA0;Parsetree.attribute&#xA0;-&gt;&#xA0;Parsetree.attribute;
@@ -117,4 +117,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;restore:bool&#xA0;-&gt;&#xA0;Parsetree.signature&#xA0;-&gt;&#xA0;Parsetree.signature
 &#xA0;&#xA0;val&#xA0;set_cookie&#xA0;:&#xA0;string&#xA0;-&gt;&#xA0;Parsetree.expression&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;val&#xA0;get_cookie&#xA0;:&#xA0;string&#xA0;-&gt;&#xA0;Parsetree.expression&#xA0;option
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Asttypes.html
+++ b/src/pages/api/type_Asttypes.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;constant&#xA0;=
 &#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;Const_int&#xA0;of&#xA0;int
 &#xA0;&#xA0;&#xA0;&#xA0;|&#xA0;Const_char&#xA0;of&#xA0;char
@@ -18,4 +18,4 @@
 &#xA0;&#xA0;type&#xA0;label&#xA0;=&#xA0;string
 &#xA0;&#xA0;type&#xA0;&apos;a&#xA0;loc&#xA0;=&#xA0;&apos;a&#xA0;Location.loc&#xA0;=&#xA0;{&#xA0;txt&#xA0;:&#xA0;&apos;a;&#xA0;loc&#xA0;:&#xA0;Location.t;&#xA0;}
 &#xA0;&#xA0;type&#xA0;variance&#xA0;=&#xA0;Covariant&#xA0;|&#xA0;Contravariant&#xA0;|&#xA0;Invariant
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Bigarray.Array1.html
+++ b/src/pages/api/type_Bigarray.Array1.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;(&apos;a,&#xA0;&apos;b,&#xA0;&apos;c)&#xA0;t
 &#xA0;&#xA0;val&#xA0;create&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;(&apos;a,&#xA0;&apos;b)&#xA0;Bigarray.kind&#xA0;-&gt;
@@ -33,4 +33,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;=&#xA0;&quot;%caml_ba_unsafe_ref_1&quot;
 &#xA0;&#xA0;external&#xA0;unsafe_set&#xA0;:&#xA0;(&apos;a,&#xA0;&apos;b,&#xA0;&apos;c)&#xA0;Bigarray.Array1.t&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;&#xA0;&#xA0;=&#xA0;&quot;%caml_ba_unsafe_set_1&quot;
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Bigarray.Array2.html
+++ b/src/pages/api/type_Bigarray.Array2.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;(&apos;a,&#xA0;&apos;b,&#xA0;&apos;c)&#xA0;t
 &#xA0;&#xA0;val&#xA0;create&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;(&apos;a,&#xA0;&apos;b)&#xA0;Bigarray.kind&#xA0;-&gt;
@@ -47,4 +47,4 @@
 &#xA0;&#xA0;external&#xA0;unsafe_set&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;(&apos;a,&#xA0;&apos;b,&#xA0;&apos;c)&#xA0;Bigarray.Array2.t&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;&#xA0;&#xA0;=&#xA0;&quot;%caml_ba_unsafe_set_2&quot;
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Bigarray.Array3.html
+++ b/src/pages/api/type_Bigarray.Array3.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;(&apos;a,&#xA0;&apos;b,&#xA0;&apos;c)&#xA0;t
 &#xA0;&#xA0;val&#xA0;create&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;(&apos;a,&#xA0;&apos;b)&#xA0;Bigarray.kind&#xA0;-&gt;
@@ -57,4 +57,4 @@
 &#xA0;&#xA0;external&#xA0;unsafe_set&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;(&apos;a,&#xA0;&apos;b,&#xA0;&apos;c)&#xA0;Bigarray.Array3.t&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;&#xA0;&#xA0;=&#xA0;&quot;%caml_ba_unsafe_set_3&quot;
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Bigarray.Genarray.html
+++ b/src/pages/api/type_Bigarray.Genarray.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;(&apos;a,&#xA0;&apos;b,&#xA0;&apos;c)&#xA0;t
 &#xA0;&#xA0;external&#xA0;create&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;(&apos;a,&#xA0;&apos;b)&#xA0;Bigarray.kind&#xA0;-&gt;
@@ -45,4 +45,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;(&apos;a,&#xA0;&apos;b)&#xA0;Bigarray.kind&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;&apos;c&#xA0;Bigarray.layout&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;bool&#xA0;-&gt;&#xA0;int&#xA0;array&#xA0;-&gt;&#xA0;(&apos;a,&#xA0;&apos;b,&#xA0;&apos;c)&#xA0;Bigarray.Genarray.t
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Bigarray.html
+++ b/src/pages/api/type_Bigarray.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;float32_elt&#xA0;=&#xA0;Float32_elt
 &#xA0;&#xA0;type&#xA0;float64_elt&#xA0;=&#xA0;Float64_elt
 &#xA0;&#xA0;type&#xA0;int8_signed_elt&#xA0;=&#xA0;Int8_signed_elt
@@ -283,4 +283,4 @@
 &#xA0;&#xA0;val&#xA0;reshape_3&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;(&apos;a,&#xA0;&apos;b,&#xA0;&apos;c)&#xA0;Bigarray.Genarray.t&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;int&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;(&apos;a,&#xA0;&apos;b,&#xA0;&apos;c)&#xA0;Bigarray.Array3.t
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Buffer.html
+++ b/src/pages/api/type_Buffer.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;t
 &#xA0;&#xA0;val&#xA0;create&#xA0;:&#xA0;int&#xA0;-&gt;&#xA0;Buffer.t
 &#xA0;&#xA0;val&#xA0;contents&#xA0;:&#xA0;Buffer.t&#xA0;-&gt;&#xA0;string
@@ -19,4 +19,4 @@
 &#xA0;&#xA0;val&#xA0;add_buffer&#xA0;:&#xA0;Buffer.t&#xA0;-&gt;&#xA0;Buffer.t&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;val&#xA0;add_channel&#xA0;:&#xA0;Buffer.t&#xA0;-&gt;&#xA0;Pervasives.in_channel&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;val&#xA0;output_buffer&#xA0;:&#xA0;Pervasives.out_channel&#xA0;-&gt;&#xA0;Buffer.t&#xA0;-&gt;&#xA0;unit
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Bytes.html
+++ b/src/pages/api/type_Bytes.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;external&#xA0;length&#xA0;:&#xA0;bytes&#xA0;-&gt;&#xA0;int&#xA0;=&#xA0;&quot;%string_length&quot;
 &#xA0;&#xA0;external&#xA0;get&#xA0;:&#xA0;bytes&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;char&#xA0;=&#xA0;&quot;%string_safe_get&quot;
 &#xA0;&#xA0;external&#xA0;set&#xA0;:&#xA0;bytes&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;char&#xA0;-&gt;&#xA0;unit&#xA0;=&#xA0;&quot;%string_safe_set&quot;
@@ -45,4 +45,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;=&#xA0;&quot;caml_blit_string&quot;&#xA0;&quot;noalloc&quot;
 &#xA0;&#xA0;external&#xA0;unsafe_fill&#xA0;:&#xA0;bytes&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;char&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;&#xA0;&#xA0;=&#xA0;&quot;caml_fill_string&quot;&#xA0;&quot;noalloc&quot;
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_BytesLabels.html
+++ b/src/pages/api/type_BytesLabels.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;external&#xA0;length&#xA0;:&#xA0;bytes&#xA0;-&gt;&#xA0;int&#xA0;=&#xA0;&quot;%string_length&quot;
 &#xA0;&#xA0;external&#xA0;get&#xA0;:&#xA0;bytes&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;char&#xA0;=&#xA0;&quot;%string_safe_get&quot;
 &#xA0;&#xA0;external&#xA0;set&#xA0;:&#xA0;bytes&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;char&#xA0;-&gt;&#xA0;unit&#xA0;=&#xA0;&quot;%string_safe_set&quot;
@@ -44,4 +44,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;=&#xA0;&quot;caml_fill_string&quot;&#xA0;&quot;noalloc&quot;
 &#xA0;&#xA0;val&#xA0;unsafe_to_string&#xA0;:&#xA0;bytes&#xA0;-&gt;&#xA0;string
 &#xA0;&#xA0;val&#xA0;unsafe_of_string&#xA0;:&#xA0;string&#xA0;-&gt;&#xA0;bytes
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Callback.html
+++ b/src/pages/api/type_Callback.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;register&#xA0;:&#xA0;string&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;val&#xA0;register_exception&#xA0;:&#xA0;string&#xA0;-&gt;&#xA0;exn&#xA0;-&gt;&#xA0;unit
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_CamlinternalFormat.html
+++ b/src/pages/api/type_CamlinternalFormat.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;is_in_char_set&#xA0;:&#xA0;CamlinternalFormatBasics.char_set&#xA0;-&gt;&#xA0;char&#xA0;-&gt;&#xA0;bool
 &#xA0;&#xA0;val&#xA0;rev_char_set&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;CamlinternalFormatBasics.char_set&#xA0;-&gt;&#xA0;CamlinternalFormatBasics.char_set
@@ -97,4 +97,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;(&apos;a1,&#xA0;&apos;b1,&#xA0;&apos;c1,&#xA0;&apos;d1,&#xA0;&apos;e1,&#xA0;&apos;f1,&#xA0;&apos;a2,&#xA0;&apos;b2,&#xA0;&apos;c2,&#xA0;&apos;d2,&#xA0;&apos;e2,&#xA0;&apos;f2)
 &#xA0;&#xA0;&#xA0;&#xA0;CamlinternalFormatBasics.fmtty_rel&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;(&apos;a2,&#xA0;&apos;b2,&#xA0;&apos;c2,&#xA0;&apos;d2,&#xA0;&apos;e2,&#xA0;&apos;f2)&#xA0;CamlinternalFormatBasics.fmt
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_CamlinternalFormatBasics.html
+++ b/src/pages/api/type_CamlinternalFormatBasics.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;padty&#xA0;=&#xA0;Left&#xA0;|&#xA0;Right&#xA0;|&#xA0;Zeros
 &#xA0;&#xA0;type&#xA0;int_conv&#xA0;=
 &#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;Int_d
@@ -399,4 +399,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;(&apos;a,&#xA0;&apos;b,&#xA0;&apos;c,&#xA0;&apos;d,&#xA0;&apos;e,&#xA0;&apos;f)&#xA0;CamlinternalFormatBasics.fmt&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;(&apos;f,&#xA0;&apos;b,&#xA0;&apos;c,&#xA0;&apos;e,&#xA0;&apos;g,&#xA0;&apos;h)&#xA0;CamlinternalFormatBasics.fmt&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;(&apos;a,&#xA0;&apos;b,&#xA0;&apos;c,&#xA0;&apos;d,&#xA0;&apos;g,&#xA0;&apos;h)&#xA0;CamlinternalFormatBasics.fmt
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_CamlinternalLazy.html
+++ b/src/pages/api/type_CamlinternalLazy.html
@@ -1,8 +1,8 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;exception&#xA0;Undefined
 &#xA0;&#xA0;val&#xA0;force_lazy_block&#xA0;:&#xA0;&apos;a&#xA0;lazy_t&#xA0;-&gt;&#xA0;&apos;a
 &#xA0;&#xA0;val&#xA0;force_val_lazy_block&#xA0;:&#xA0;&apos;a&#xA0;lazy_t&#xA0;-&gt;&#xA0;&apos;a
 &#xA0;&#xA0;val&#xA0;force&#xA0;:&#xA0;&apos;a&#xA0;lazy_t&#xA0;-&gt;&#xA0;&apos;a
 &#xA0;&#xA0;val&#xA0;force_val&#xA0;:&#xA0;&apos;a&#xA0;lazy_t&#xA0;-&gt;&#xA0;&apos;a
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_CamlinternalMod.html
+++ b/src/pages/api/type_CamlinternalMod.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;shape&#xA0;=
 &#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;Function
 &#xA0;&#xA0;&#xA0;&#xA0;|&#xA0;Lazy
@@ -8,4 +8,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;|&#xA0;Value&#xA0;of&#xA0;Obj.t
 &#xA0;&#xA0;val&#xA0;init_mod&#xA0;:&#xA0;string&#xA0;*&#xA0;int&#xA0;*&#xA0;int&#xA0;-&gt;&#xA0;CamlinternalMod.shape&#xA0;-&gt;&#xA0;Obj.t
 &#xA0;&#xA0;val&#xA0;update_mod&#xA0;:&#xA0;CamlinternalMod.shape&#xA0;-&gt;&#xA0;Obj.t&#xA0;-&gt;&#xA0;Obj.t&#xA0;-&gt;&#xA0;unit
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_CamlinternalOO.html
+++ b/src/pages/api/type_CamlinternalOO.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;tag
 &#xA0;&#xA0;type&#xA0;label
 &#xA0;&#xA0;type&#xA0;table
@@ -119,4 +119,4 @@
 &#xA0;&#xA0;val&#xA0;params&#xA0;:&#xA0;CamlinternalOO.params
 &#xA0;&#xA0;type&#xA0;stats&#xA0;=&#xA0;{&#xA0;classes&#xA0;:&#xA0;int;&#xA0;methods&#xA0;:&#xA0;int;&#xA0;inst_vars&#xA0;:&#xA0;int;&#xA0;}
 &#xA0;&#xA0;val&#xA0;stats&#xA0;:&#xA0;unit&#xA0;-&gt;&#xA0;CamlinternalOO.stats
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Char.html
+++ b/src/pages/api/type_Char.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;external&#xA0;code&#xA0;:&#xA0;char&#xA0;-&gt;&#xA0;int&#xA0;=&#xA0;&quot;%identity&quot;
 &#xA0;&#xA0;val&#xA0;chr&#xA0;:&#xA0;int&#xA0;-&gt;&#xA0;char
 &#xA0;&#xA0;val&#xA0;escaped&#xA0;:&#xA0;char&#xA0;-&gt;&#xA0;string
@@ -8,4 +8,4 @@
 &#xA0;&#xA0;type&#xA0;t&#xA0;=&#xA0;char
 &#xA0;&#xA0;val&#xA0;compare&#xA0;:&#xA0;Char.t&#xA0;-&gt;&#xA0;Char.t&#xA0;-&gt;&#xA0;int
 &#xA0;&#xA0;external&#xA0;unsafe_chr&#xA0;:&#xA0;int&#xA0;-&gt;&#xA0;char&#xA0;=&#xA0;&quot;%identity&quot;
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Complex.html
+++ b/src/pages/api/type_Complex.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;t&#xA0;=&#xA0;{&#xA0;re&#xA0;:&#xA0;float;&#xA0;im&#xA0;:&#xA0;float;&#xA0;}
 &#xA0;&#xA0;val&#xA0;zero&#xA0;:&#xA0;Complex.t
 &#xA0;&#xA0;val&#xA0;one&#xA0;:&#xA0;Complex.t
@@ -19,4 +19,4 @@
 &#xA0;&#xA0;val&#xA0;exp&#xA0;:&#xA0;Complex.t&#xA0;-&gt;&#xA0;Complex.t
 &#xA0;&#xA0;val&#xA0;log&#xA0;:&#xA0;Complex.t&#xA0;-&gt;&#xA0;Complex.t
 &#xA0;&#xA0;val&#xA0;pow&#xA0;:&#xA0;Complex.t&#xA0;-&gt;&#xA0;Complex.t&#xA0;-&gt;&#xA0;Complex.t
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Digest.html
+++ b/src/pages/api/type_Digest.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;t&#xA0;=&#xA0;string
 &#xA0;&#xA0;val&#xA0;compare&#xA0;:&#xA0;Digest.t&#xA0;-&gt;&#xA0;Digest.t&#xA0;-&gt;&#xA0;int
 &#xA0;&#xA0;val&#xA0;string&#xA0;:&#xA0;string&#xA0;-&gt;&#xA0;Digest.t
@@ -13,4 +13,4 @@
 &#xA0;&#xA0;val&#xA0;input&#xA0;:&#xA0;Pervasives.in_channel&#xA0;-&gt;&#xA0;Digest.t
 &#xA0;&#xA0;val&#xA0;to_hex&#xA0;:&#xA0;Digest.t&#xA0;-&gt;&#xA0;string
 &#xA0;&#xA0;val&#xA0;from_hex&#xA0;:&#xA0;string&#xA0;-&gt;&#xA0;Digest.t
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Docstrings.html
+++ b/src/pages/api/type_Docstrings.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;init&#xA0;:&#xA0;unit&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;val&#xA0;warn_bad_docstrings&#xA0;:&#xA0;unit&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;type&#xA0;docstring
@@ -50,4 +50,4 @@
 &#xA0;&#xA0;val&#xA0;symbol_post_extra_text&#xA0;:&#xA0;unit&#xA0;-&gt;&#xA0;Docstrings.text
 &#xA0;&#xA0;val&#xA0;rhs_pre_extra_text&#xA0;:&#xA0;int&#xA0;-&gt;&#xA0;Docstrings.text
 &#xA0;&#xA0;val&#xA0;rhs_post_extra_text&#xA0;:&#xA0;int&#xA0;-&gt;&#xA0;Docstrings.text
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Filename.html
+++ b/src/pages/api/type_Filename.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;current_dir_name&#xA0;:&#xA0;string
 &#xA0;&#xA0;val&#xA0;parent_dir_name&#xA0;:&#xA0;string
 &#xA0;&#xA0;val&#xA0;dir_sep&#xA0;:&#xA0;string
@@ -19,4 +19,4 @@
 &#xA0;&#xA0;val&#xA0;set_temp_dir_name&#xA0;:&#xA0;string&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;val&#xA0;temp_dir_name&#xA0;:&#xA0;string
 &#xA0;&#xA0;val&#xA0;quote&#xA0;:&#xA0;string&#xA0;-&gt;&#xA0;string
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Format.html
+++ b/src/pages/api/type_Format.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;open_box&#xA0;:&#xA0;int&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;val&#xA0;close_box&#xA0;:&#xA0;unit&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;val&#xA0;print_string&#xA0;:&#xA0;string&#xA0;-&gt;&#xA0;unit
@@ -173,4 +173,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;unit&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;(string&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;unit)&#xA0;*&#xA0;(unit&#xA0;-&gt;&#xA0;unit)&#xA0;*&#xA0;(unit&#xA0;-&gt;&#xA0;unit)&#xA0;*
 &#xA0;&#xA0;&#xA0;&#xA0;(int&#xA0;-&gt;&#xA0;unit)
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Gc.html
+++ b/src/pages/api/type_Gc.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;stat&#xA0;=&#xA0;{
 &#xA0;&#xA0;&#xA0;&#xA0;minor_words&#xA0;:&#xA0;float;
 &#xA0;&#xA0;&#xA0;&#xA0;promoted_words&#xA0;:&#xA0;float;
@@ -44,4 +44,4 @@
 &#xA0;&#xA0;type&#xA0;alarm
 &#xA0;&#xA0;val&#xA0;create_alarm&#xA0;:&#xA0;(unit&#xA0;-&gt;&#xA0;unit)&#xA0;-&gt;&#xA0;Gc.alarm
 &#xA0;&#xA0;val&#xA0;delete_alarm&#xA0;:&#xA0;Gc.alarm&#xA0;-&gt;&#xA0;unit
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Genlex.html
+++ b/src/pages/api/type_Genlex.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;token&#xA0;=
 &#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;Kwd&#xA0;of&#xA0;string
 &#xA0;&#xA0;&#xA0;&#xA0;|&#xA0;Ident&#xA0;of&#xA0;string
@@ -8,4 +8,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;|&#xA0;String&#xA0;of&#xA0;string
 &#xA0;&#xA0;&#xA0;&#xA0;|&#xA0;Char&#xA0;of&#xA0;char
 &#xA0;&#xA0;val&#xA0;make_lexer&#xA0;:&#xA0;string&#xA0;list&#xA0;-&gt;&#xA0;char&#xA0;Stream.t&#xA0;-&gt;&#xA0;Genlex.token&#xA0;Stream.t
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Hashtbl.HashedType.html
+++ b/src/pages/api/type_Hashtbl.HashedType.html
@@ -1,6 +1,6 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;t
 &#xA0;&#xA0;val&#xA0;equal&#xA0;:&#xA0;Hashtbl.HashedType.t&#xA0;-&gt;&#xA0;Hashtbl.HashedType.t&#xA0;-&gt;&#xA0;bool
 &#xA0;&#xA0;val&#xA0;hash&#xA0;:&#xA0;Hashtbl.HashedType.t&#xA0;-&gt;&#xA0;int
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Hashtbl.Make.html
+++ b/src/pages/api/type_Hashtbl.Make.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">functor&#xA0;(H&#xA0;:&#xA0;HashedType)&#xA0;-&gt;
+<div class="ocamldoc"><pre>functor&#xA0;(H&#xA0;:&#xA0;HashedType)&#xA0;-&gt;
+
 &#xA0;&#xA0;sig
 &#xA0;&#xA0;&#xA0;&#xA0;type&#xA0;key&#xA0;=&#xA0;H.t
 &#xA0;&#xA0;&#xA0;&#xA0;type&#xA0;&apos;a&#xA0;t
@@ -17,4 +17,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;fold&#xA0;:&#xA0;(key&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;&apos;b&#xA0;-&gt;&#xA0;&apos;b)&#xA0;-&gt;&#xA0;&apos;a&#xA0;t&#xA0;-&gt;&#xA0;&apos;b&#xA0;-&gt;&#xA0;&apos;b
 &#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;length&#xA0;:&#xA0;&apos;a&#xA0;t&#xA0;-&gt;&#xA0;int
 &#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;stats&#xA0;:&#xA0;&apos;a&#xA0;t&#xA0;-&gt;&#xA0;statistics
-&#xA0;&#xA0;end</code></div>
+&#xA0;&#xA0;end</pre></div>

--- a/src/pages/api/type_Hashtbl.MakeSeeded.html
+++ b/src/pages/api/type_Hashtbl.MakeSeeded.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">functor&#xA0;(H&#xA0;:&#xA0;SeededHashedType)&#xA0;-&gt;
+<div class="ocamldoc"><pre>functor&#xA0;(H&#xA0;:&#xA0;SeededHashedType)&#xA0;-&gt;
+
 &#xA0;&#xA0;sig
 &#xA0;&#xA0;&#xA0;&#xA0;type&#xA0;key&#xA0;=&#xA0;H.t
 &#xA0;&#xA0;&#xA0;&#xA0;type&#xA0;&apos;a&#xA0;t
@@ -17,4 +17,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;fold&#xA0;:&#xA0;(key&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;&apos;b&#xA0;-&gt;&#xA0;&apos;b)&#xA0;-&gt;&#xA0;&apos;a&#xA0;t&#xA0;-&gt;&#xA0;&apos;b&#xA0;-&gt;&#xA0;&apos;b
 &#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;length&#xA0;:&#xA0;&apos;a&#xA0;t&#xA0;-&gt;&#xA0;int
 &#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;stats&#xA0;:&#xA0;&apos;a&#xA0;t&#xA0;-&gt;&#xA0;statistics
-&#xA0;&#xA0;end</code></div>
+&#xA0;&#xA0;end</pre></div>

--- a/src/pages/api/type_Hashtbl.S.html
+++ b/src/pages/api/type_Hashtbl.S.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;key
 &#xA0;&#xA0;type&#xA0;&apos;a&#xA0;t
 &#xA0;&#xA0;val&#xA0;create&#xA0;:&#xA0;int&#xA0;-&gt;&#xA0;&apos;a&#xA0;Hashtbl.S.t
@@ -16,4 +16,4 @@
 &#xA0;&#xA0;val&#xA0;fold&#xA0;:&#xA0;(Hashtbl.S.key&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;&apos;b&#xA0;-&gt;&#xA0;&apos;b)&#xA0;-&gt;&#xA0;&apos;a&#xA0;Hashtbl.S.t&#xA0;-&gt;&#xA0;&apos;b&#xA0;-&gt;&#xA0;&apos;b
 &#xA0;&#xA0;val&#xA0;length&#xA0;:&#xA0;&apos;a&#xA0;Hashtbl.S.t&#xA0;-&gt;&#xA0;int
 &#xA0;&#xA0;val&#xA0;stats&#xA0;:&#xA0;&apos;a&#xA0;Hashtbl.S.t&#xA0;-&gt;&#xA0;Hashtbl.statistics
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Hashtbl.SeededHashedType.html
+++ b/src/pages/api/type_Hashtbl.SeededHashedType.html
@@ -1,7 +1,7 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;t
 &#xA0;&#xA0;val&#xA0;equal&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;Hashtbl.SeededHashedType.t&#xA0;-&gt;&#xA0;Hashtbl.SeededHashedType.t&#xA0;-&gt;&#xA0;bool
 &#xA0;&#xA0;val&#xA0;hash&#xA0;:&#xA0;int&#xA0;-&gt;&#xA0;Hashtbl.SeededHashedType.t&#xA0;-&gt;&#xA0;int
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Hashtbl.SeededS.html
+++ b/src/pages/api/type_Hashtbl.SeededS.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;key
 &#xA0;&#xA0;type&#xA0;&apos;a&#xA0;t
 &#xA0;&#xA0;val&#xA0;create&#xA0;:&#xA0;?random:bool&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;&apos;a&#xA0;Hashtbl.SeededS.t
@@ -19,4 +19,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;&apos;a&#xA0;Hashtbl.SeededS.t&#xA0;-&gt;&#xA0;&apos;b&#xA0;-&gt;&#xA0;&apos;b
 &#xA0;&#xA0;val&#xA0;length&#xA0;:&#xA0;&apos;a&#xA0;Hashtbl.SeededS.t&#xA0;-&gt;&#xA0;int
 &#xA0;&#xA0;val&#xA0;stats&#xA0;:&#xA0;&apos;a&#xA0;Hashtbl.SeededS.t&#xA0;-&gt;&#xA0;Hashtbl.statistics
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Hashtbl.html
+++ b/src/pages/api/type_Hashtbl.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;(&apos;a,&#xA0;&apos;b)&#xA0;t
 &#xA0;&#xA0;val&#xA0;create&#xA0;:&#xA0;?random:bool&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;(&apos;a,&#xA0;&apos;b)&#xA0;Hashtbl.t
 &#xA0;&#xA0;val&#xA0;clear&#xA0;:&#xA0;(&apos;a,&#xA0;&apos;b)&#xA0;Hashtbl.t&#xA0;-&gt;&#xA0;unit
@@ -121,4 +121,4 @@
 &#xA0;&#xA0;val&#xA0;seeded_hash&#xA0;:&#xA0;int&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;int
 &#xA0;&#xA0;val&#xA0;hash_param&#xA0;:&#xA0;int&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;int
 &#xA0;&#xA0;val&#xA0;seeded_hash_param&#xA0;:&#xA0;int&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;int
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Int32.html
+++ b/src/pages/api/type_Int32.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;zero&#xA0;:&#xA0;int32
 &#xA0;&#xA0;val&#xA0;one&#xA0;:&#xA0;int32
 &#xA0;&#xA0;val&#xA0;minus_one&#xA0;:&#xA0;int32
@@ -32,4 +32,4 @@
 &#xA0;&#xA0;type&#xA0;t&#xA0;=&#xA0;int32
 &#xA0;&#xA0;val&#xA0;compare&#xA0;:&#xA0;Int32.t&#xA0;-&gt;&#xA0;Int32.t&#xA0;-&gt;&#xA0;int
 &#xA0;&#xA0;external&#xA0;format&#xA0;:&#xA0;string&#xA0;-&gt;&#xA0;int32&#xA0;-&gt;&#xA0;string&#xA0;=&#xA0;&quot;caml_int32_format&quot;
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Int64.html
+++ b/src/pages/api/type_Int64.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;zero&#xA0;:&#xA0;int64
 &#xA0;&#xA0;val&#xA0;one&#xA0;:&#xA0;int64
 &#xA0;&#xA0;val&#xA0;minus_one&#xA0;:&#xA0;int64
@@ -36,4 +36,4 @@
 &#xA0;&#xA0;type&#xA0;t&#xA0;=&#xA0;int64
 &#xA0;&#xA0;val&#xA0;compare&#xA0;:&#xA0;Int64.t&#xA0;-&gt;&#xA0;Int64.t&#xA0;-&gt;&#xA0;int
 &#xA0;&#xA0;external&#xA0;format&#xA0;:&#xA0;string&#xA0;-&gt;&#xA0;int64&#xA0;-&gt;&#xA0;string&#xA0;=&#xA0;&quot;caml_int64_format&quot;
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Lazy.html
+++ b/src/pages/api/type_Lazy.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;&apos;a&#xA0;t&#xA0;=&#xA0;&apos;a&#xA0;lazy_t
 &#xA0;&#xA0;exception&#xA0;Undefined
 &#xA0;&#xA0;external&#xA0;force&#xA0;:&#xA0;&apos;a&#xA0;Lazy.t&#xA0;-&gt;&#xA0;&apos;a&#xA0;=&#xA0;&quot;%lazy_force&quot;
@@ -10,4 +10,4 @@
 &#xA0;&#xA0;val&#xA0;lazy_from_fun&#xA0;:&#xA0;(unit&#xA0;-&gt;&#xA0;&apos;a)&#xA0;-&gt;&#xA0;&apos;a&#xA0;Lazy.t
 &#xA0;&#xA0;val&#xA0;lazy_from_val&#xA0;:&#xA0;&apos;a&#xA0;-&gt;&#xA0;&apos;a&#xA0;Lazy.t
 &#xA0;&#xA0;val&#xA0;lazy_is_val&#xA0;:&#xA0;&apos;a&#xA0;Lazy.t&#xA0;-&gt;&#xA0;bool
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Lexer.html
+++ b/src/pages/api/type_Lexer.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;init&#xA0;:&#xA0;unit&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;val&#xA0;token&#xA0;:&#xA0;Lexing.lexbuf&#xA0;-&gt;&#xA0;Parser.token
 &#xA0;&#xA0;val&#xA0;skip_sharp_bang&#xA0;:&#xA0;Lexing.lexbuf&#xA0;-&gt;&#xA0;unit
@@ -22,4 +22,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;(unit&#xA0;-&gt;&#xA0;unit)&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;((Lexing.lexbuf&#xA0;-&gt;&#xA0;Parser.token)&#xA0;-&gt;&#xA0;Lexing.lexbuf&#xA0;-&gt;&#xA0;Parser.token)&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;unit
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Lexing.html
+++ b/src/pages/api/type_Lexing.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;position&#xA0;=&#xA0;{
 &#xA0;&#xA0;&#xA0;&#xA0;pos_fname&#xA0;:&#xA0;string;
 &#xA0;&#xA0;&#xA0;&#xA0;pos_lnum&#xA0;:&#xA0;int;
@@ -51,4 +51,4 @@
 &#xA0;&#xA0;}
 &#xA0;&#xA0;val&#xA0;engine&#xA0;:&#xA0;Lexing.lex_tables&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;Lexing.lexbuf&#xA0;-&gt;&#xA0;int
 &#xA0;&#xA0;val&#xA0;new_engine&#xA0;:&#xA0;Lexing.lex_tables&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;Lexing.lexbuf&#xA0;-&gt;&#xA0;int
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_List.html
+++ b/src/pages/api/type_List.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;length&#xA0;:&#xA0;&apos;a&#xA0;list&#xA0;-&gt;&#xA0;int
 &#xA0;&#xA0;val&#xA0;hd&#xA0;:&#xA0;&apos;a&#xA0;list&#xA0;-&gt;&#xA0;&apos;a
 &#xA0;&#xA0;val&#xA0;tl&#xA0;:&#xA0;&apos;a&#xA0;list&#xA0;-&gt;&#xA0;&apos;a&#xA0;list
@@ -44,4 +44,4 @@
 &#xA0;&#xA0;val&#xA0;fast_sort&#xA0;:&#xA0;(&apos;a&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;int)&#xA0;-&gt;&#xA0;&apos;a&#xA0;list&#xA0;-&gt;&#xA0;&apos;a&#xA0;list
 &#xA0;&#xA0;val&#xA0;sort_uniq&#xA0;:&#xA0;(&apos;a&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;int)&#xA0;-&gt;&#xA0;&apos;a&#xA0;list&#xA0;-&gt;&#xA0;&apos;a&#xA0;list
 &#xA0;&#xA0;val&#xA0;merge&#xA0;:&#xA0;(&apos;a&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;int)&#xA0;-&gt;&#xA0;&apos;a&#xA0;list&#xA0;-&gt;&#xA0;&apos;a&#xA0;list&#xA0;-&gt;&#xA0;&apos;a&#xA0;list
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_ListLabels.html
+++ b/src/pages/api/type_ListLabels.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;length&#xA0;:&#xA0;&apos;a&#xA0;list&#xA0;-&gt;&#xA0;int
 &#xA0;&#xA0;val&#xA0;hd&#xA0;:&#xA0;&apos;a&#xA0;list&#xA0;-&gt;&#xA0;&apos;a
 &#xA0;&#xA0;val&#xA0;tl&#xA0;:&#xA0;&apos;a&#xA0;list&#xA0;-&gt;&#xA0;&apos;a&#xA0;list
@@ -45,4 +45,4 @@
 &#xA0;&#xA0;val&#xA0;stable_sort&#xA0;:&#xA0;cmp:(&apos;a&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;int)&#xA0;-&gt;&#xA0;&apos;a&#xA0;list&#xA0;-&gt;&#xA0;&apos;a&#xA0;list
 &#xA0;&#xA0;val&#xA0;fast_sort&#xA0;:&#xA0;cmp:(&apos;a&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;int)&#xA0;-&gt;&#xA0;&apos;a&#xA0;list&#xA0;-&gt;&#xA0;&apos;a&#xA0;list
 &#xA0;&#xA0;val&#xA0;merge&#xA0;:&#xA0;cmp:(&apos;a&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;int)&#xA0;-&gt;&#xA0;&apos;a&#xA0;list&#xA0;-&gt;&#xA0;&apos;a&#xA0;list&#xA0;-&gt;&#xA0;&apos;a&#xA0;list
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Location.html
+++ b/src/pages/api/type_Location.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;t&#xA0;=&#xA0;{
 &#xA0;&#xA0;&#xA0;&#xA0;loc_start&#xA0;:&#xA0;Lexing.position;
 &#xA0;&#xA0;&#xA0;&#xA0;loc_end&#xA0;:&#xA0;Lexing.position;
@@ -67,4 +67,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;(Format.formatter&#xA0;-&gt;&#xA0;Location.error&#xA0;-&gt;&#xA0;unit)&#xA0;Pervasives.ref
 &#xA0;&#xA0;val&#xA0;default_error_reporter&#xA0;:&#xA0;Format.formatter&#xA0;-&gt;&#xA0;Location.error&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;val&#xA0;report_exception&#xA0;:&#xA0;Format.formatter&#xA0;-&gt;&#xA0;exn&#xA0;-&gt;&#xA0;unit
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Longident.html
+++ b/src/pages/api/type_Longident.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;t&#xA0;=
 &#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;Lident&#xA0;of&#xA0;string
 &#xA0;&#xA0;&#xA0;&#xA0;|&#xA0;Ldot&#xA0;of&#xA0;Longident.t&#xA0;*&#xA0;string
@@ -7,4 +7,4 @@
 &#xA0;&#xA0;val&#xA0;flatten&#xA0;:&#xA0;Longident.t&#xA0;-&gt;&#xA0;string&#xA0;list
 &#xA0;&#xA0;val&#xA0;last&#xA0;:&#xA0;Longident.t&#xA0;-&gt;&#xA0;string
 &#xA0;&#xA0;val&#xA0;parse&#xA0;:&#xA0;string&#xA0;-&gt;&#xA0;Longident.t
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Map.Make.html
+++ b/src/pages/api/type_Map.Make.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">functor&#xA0;(Ord&#xA0;:&#xA0;OrderedType)&#xA0;-&gt;
+<div class="ocamldoc"><pre>functor&#xA0;(Ord&#xA0;:&#xA0;OrderedType)&#xA0;-&gt;
+
 &#xA0;&#xA0;sig
 &#xA0;&#xA0;&#xA0;&#xA0;type&#xA0;key&#xA0;=&#xA0;Ord.t
 &#xA0;&#xA0;&#xA0;&#xA0;type&#xA0;+&apos;a&#xA0;t
@@ -28,4 +28,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;find&#xA0;:&#xA0;key&#xA0;-&gt;&#xA0;&apos;a&#xA0;t&#xA0;-&gt;&#xA0;&apos;a
 &#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;map&#xA0;:&#xA0;(&apos;a&#xA0;-&gt;&#xA0;&apos;b)&#xA0;-&gt;&#xA0;&apos;a&#xA0;t&#xA0;-&gt;&#xA0;&apos;b&#xA0;t
 &#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;mapi&#xA0;:&#xA0;(key&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;&apos;b)&#xA0;-&gt;&#xA0;&apos;a&#xA0;t&#xA0;-&gt;&#xA0;&apos;b&#xA0;t
-&#xA0;&#xA0;end</code></div>
+&#xA0;&#xA0;end</pre></div>

--- a/src/pages/api/type_Map.OrderedType.html
+++ b/src/pages/api/type_Map.OrderedType.html
@@ -1,2 +1,1 @@
-<div class="ocamldoc">
-<code class="code">sig&#xA0;type&#xA0;t&#xA0;val&#xA0;compare&#xA0;:&#xA0;Map.OrderedType.t&#xA0;-&gt;&#xA0;Map.OrderedType.t&#xA0;-&gt;&#xA0;int&#xA0;end</code></div>
+<div class="ocamldoc"><pre>sig&#xA0;type&#xA0;t&#xA0;val&#xA0;compare&#xA0;:&#xA0;Map.OrderedType.t&#xA0;-&gt;&#xA0;Map.OrderedType.t&#xA0;-&gt;&#xA0;int&#xA0;end</pre></div>

--- a/src/pages/api/type_Map.S.html
+++ b/src/pages/api/type_Map.S.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;key
 &#xA0;&#xA0;type&#xA0;+&apos;a&#xA0;t
 &#xA0;&#xA0;val&#xA0;empty&#xA0;:&#xA0;&apos;a&#xA0;Map.S.t
@@ -29,4 +29,4 @@
 &#xA0;&#xA0;val&#xA0;find&#xA0;:&#xA0;Map.S.key&#xA0;-&gt;&#xA0;&apos;a&#xA0;Map.S.t&#xA0;-&gt;&#xA0;&apos;a
 &#xA0;&#xA0;val&#xA0;map&#xA0;:&#xA0;(&apos;a&#xA0;-&gt;&#xA0;&apos;b)&#xA0;-&gt;&#xA0;&apos;a&#xA0;Map.S.t&#xA0;-&gt;&#xA0;&apos;b&#xA0;Map.S.t
 &#xA0;&#xA0;val&#xA0;mapi&#xA0;:&#xA0;(Map.S.key&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;&apos;b)&#xA0;-&gt;&#xA0;&apos;a&#xA0;Map.S.t&#xA0;-&gt;&#xA0;&apos;b&#xA0;Map.S.t
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Map.html
+++ b/src/pages/api/type_Map.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;module&#xA0;type&#xA0;OrderedType&#xA0;=
 &#xA0;&#xA0;&#xA0;&#xA0;sig
 &#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;type&#xA0;t
@@ -70,4 +70,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;map&#xA0;:&#xA0;(&apos;a&#xA0;-&gt;&#xA0;&apos;b)&#xA0;-&gt;&#xA0;&apos;a&#xA0;t&#xA0;-&gt;&#xA0;&apos;b&#xA0;t
 &#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;mapi&#xA0;:&#xA0;(key&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;&apos;b)&#xA0;-&gt;&#xA0;&apos;a&#xA0;t&#xA0;-&gt;&#xA0;&apos;b&#xA0;t
 &#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;end
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Marshal.html
+++ b/src/pages/api/type_Marshal.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;extern_flags&#xA0;=&#xA0;No_sharing&#xA0;|&#xA0;Closures&#xA0;|&#xA0;Compat_32
 &#xA0;&#xA0;val&#xA0;to_channel&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;Pervasives.out_channel&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;Marshal.extern_flags&#xA0;list&#xA0;-&gt;&#xA0;unit
@@ -15,4 +15,4 @@
 &#xA0;&#xA0;val&#xA0;header_size&#xA0;:&#xA0;int
 &#xA0;&#xA0;val&#xA0;data_size&#xA0;:&#xA0;bytes&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;int
 &#xA0;&#xA0;val&#xA0;total_size&#xA0;:&#xA0;bytes&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;int
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_MoreLabels.Hashtbl.HashedType.html
+++ b/src/pages/api/type_MoreLabels.Hashtbl.HashedType.html
@@ -1,2 +1,1 @@
-<div class="ocamldoc">
-<code class="code">Hashtbl.HashedType</code></div>
+<div class="ocamldoc"><pre>Hashtbl.HashedType</pre></div>

--- a/src/pages/api/type_MoreLabels.Hashtbl.Make.html
+++ b/src/pages/api/type_MoreLabels.Hashtbl.Make.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">functor&#xA0;(H&#xA0;:&#xA0;HashedType)&#xA0;-&gt;
+<div class="ocamldoc"><pre>functor&#xA0;(H&#xA0;:&#xA0;HashedType)&#xA0;-&gt;
+
 &#xA0;&#xA0;sig
 &#xA0;&#xA0;&#xA0;&#xA0;type&#xA0;key&#xA0;=&#xA0;H.t
 &#xA0;&#xA0;&#xA0;&#xA0;and&#xA0;&apos;a&#xA0;t
@@ -17,4 +17,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;fold&#xA0;:&#xA0;f:(key:key&#xA0;-&gt;&#xA0;data:&apos;a&#xA0;-&gt;&#xA0;&apos;b&#xA0;-&gt;&#xA0;&apos;b)&#xA0;-&gt;&#xA0;&apos;a&#xA0;t&#xA0;-&gt;&#xA0;init:&apos;b&#xA0;-&gt;&#xA0;&apos;b
 &#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;length&#xA0;:&#xA0;&apos;a&#xA0;t&#xA0;-&gt;&#xA0;int
 &#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;stats&#xA0;:&#xA0;&apos;a&#xA0;t&#xA0;-&gt;&#xA0;statistics
-&#xA0;&#xA0;end</code></div>
+&#xA0;&#xA0;end</pre></div>

--- a/src/pages/api/type_MoreLabels.Hashtbl.MakeSeeded.html
+++ b/src/pages/api/type_MoreLabels.Hashtbl.MakeSeeded.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">functor&#xA0;(H&#xA0;:&#xA0;SeededHashedType)&#xA0;-&gt;
+<div class="ocamldoc"><pre>functor&#xA0;(H&#xA0;:&#xA0;SeededHashedType)&#xA0;-&gt;
+
 &#xA0;&#xA0;sig
 &#xA0;&#xA0;&#xA0;&#xA0;type&#xA0;key&#xA0;=&#xA0;H.t
 &#xA0;&#xA0;&#xA0;&#xA0;and&#xA0;&apos;a&#xA0;t
@@ -17,4 +17,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;fold&#xA0;:&#xA0;f:(key:key&#xA0;-&gt;&#xA0;data:&apos;a&#xA0;-&gt;&#xA0;&apos;b&#xA0;-&gt;&#xA0;&apos;b)&#xA0;-&gt;&#xA0;&apos;a&#xA0;t&#xA0;-&gt;&#xA0;init:&apos;b&#xA0;-&gt;&#xA0;&apos;b
 &#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;length&#xA0;:&#xA0;&apos;a&#xA0;t&#xA0;-&gt;&#xA0;int
 &#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;stats&#xA0;:&#xA0;&apos;a&#xA0;t&#xA0;-&gt;&#xA0;statistics
-&#xA0;&#xA0;end</code></div>
+&#xA0;&#xA0;end</pre></div>

--- a/src/pages/api/type_MoreLabels.Hashtbl.S.html
+++ b/src/pages/api/type_MoreLabels.Hashtbl.S.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;key
 &#xA0;&#xA0;and&#xA0;&apos;a&#xA0;t
 &#xA0;&#xA0;val&#xA0;create&#xA0;:&#xA0;int&#xA0;-&gt;&#xA0;&apos;a&#xA0;MoreLabels.Hashtbl.S.t
@@ -25,4 +25,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;&apos;a&#xA0;MoreLabels.Hashtbl.S.t&#xA0;-&gt;&#xA0;init:&apos;b&#xA0;-&gt;&#xA0;&apos;b
 &#xA0;&#xA0;val&#xA0;length&#xA0;:&#xA0;&apos;a&#xA0;MoreLabels.Hashtbl.S.t&#xA0;-&gt;&#xA0;int
 &#xA0;&#xA0;val&#xA0;stats&#xA0;:&#xA0;&apos;a&#xA0;MoreLabels.Hashtbl.S.t&#xA0;-&gt;&#xA0;MoreLabels.Hashtbl.statistics
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_MoreLabels.Hashtbl.SeededHashedType.html
+++ b/src/pages/api/type_MoreLabels.Hashtbl.SeededHashedType.html
@@ -1,2 +1,1 @@
-<div class="ocamldoc">
-<code class="code">Hashtbl.SeededHashedType</code></div>
+<div class="ocamldoc"><pre>Hashtbl.SeededHashedType</pre></div>

--- a/src/pages/api/type_MoreLabels.Hashtbl.SeededS.html
+++ b/src/pages/api/type_MoreLabels.Hashtbl.SeededS.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;key
 &#xA0;&#xA0;and&#xA0;&apos;a&#xA0;t
 &#xA0;&#xA0;val&#xA0;create&#xA0;:&#xA0;?random:bool&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;&apos;a&#xA0;MoreLabels.Hashtbl.SeededS.t
@@ -31,4 +31,4 @@
 &#xA0;&#xA0;val&#xA0;length&#xA0;:&#xA0;&apos;a&#xA0;MoreLabels.Hashtbl.SeededS.t&#xA0;-&gt;&#xA0;int
 &#xA0;&#xA0;val&#xA0;stats&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;&apos;a&#xA0;MoreLabels.Hashtbl.SeededS.t&#xA0;-&gt;&#xA0;MoreLabels.Hashtbl.statistics
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_MoreLabels.Hashtbl.html
+++ b/src/pages/api/type_MoreLabels.Hashtbl.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;(&apos;a,&#xA0;&apos;b)&#xA0;t&#xA0;=&#xA0;(&apos;a,&#xA0;&apos;b)&#xA0;Hashtbl.t
 &#xA0;&#xA0;val&#xA0;create&#xA0;:&#xA0;?random:bool&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;(&apos;a,&#xA0;&apos;b)&#xA0;MoreLabels.Hashtbl.t
 &#xA0;&#xA0;val&#xA0;clear&#xA0;:&#xA0;(&apos;a,&#xA0;&apos;b)&#xA0;MoreLabels.Hashtbl.t&#xA0;-&gt;&#xA0;unit
@@ -134,4 +134,4 @@
 &#xA0;&#xA0;val&#xA0;seeded_hash&#xA0;:&#xA0;int&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;int
 &#xA0;&#xA0;val&#xA0;hash_param&#xA0;:&#xA0;int&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;int
 &#xA0;&#xA0;val&#xA0;seeded_hash_param&#xA0;:&#xA0;int&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;int
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_MoreLabels.Map.Make.html
+++ b/src/pages/api/type_MoreLabels.Map.Make.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">functor&#xA0;(Ord&#xA0;:&#xA0;OrderedType)&#xA0;-&gt;
+<div class="ocamldoc"><pre>functor&#xA0;(Ord&#xA0;:&#xA0;OrderedType)&#xA0;-&gt;
+
 &#xA0;&#xA0;sig
 &#xA0;&#xA0;&#xA0;&#xA0;type&#xA0;key&#xA0;=&#xA0;Ord.t
 &#xA0;&#xA0;&#xA0;&#xA0;and&#xA0;+&apos;a&#xA0;t
@@ -28,4 +28,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;find&#xA0;:&#xA0;key&#xA0;-&gt;&#xA0;&apos;a&#xA0;t&#xA0;-&gt;&#xA0;&apos;a
 &#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;map&#xA0;:&#xA0;f:(&apos;a&#xA0;-&gt;&#xA0;&apos;b)&#xA0;-&gt;&#xA0;&apos;a&#xA0;t&#xA0;-&gt;&#xA0;&apos;b&#xA0;t
 &#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;mapi&#xA0;:&#xA0;f:(key&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;&apos;b)&#xA0;-&gt;&#xA0;&apos;a&#xA0;t&#xA0;-&gt;&#xA0;&apos;b&#xA0;t
-&#xA0;&#xA0;end</code></div>
+&#xA0;&#xA0;end</pre></div>

--- a/src/pages/api/type_MoreLabels.Map.OrderedType.html
+++ b/src/pages/api/type_MoreLabels.Map.OrderedType.html
@@ -1,2 +1,1 @@
-<div class="ocamldoc">
-<code class="code">Map.OrderedType</code></div>
+<div class="ocamldoc"><pre>Map.OrderedType</pre></div>

--- a/src/pages/api/type_MoreLabels.Map.S.html
+++ b/src/pages/api/type_MoreLabels.Map.S.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;key
 &#xA0;&#xA0;and&#xA0;+&apos;a&#xA0;t
 &#xA0;&#xA0;val&#xA0;empty&#xA0;:&#xA0;&apos;a&#xA0;MoreLabels.Map.S.t
@@ -50,4 +50,4 @@
 &#xA0;&#xA0;val&#xA0;mapi&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;f:(MoreLabels.Map.S.key&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;&apos;b)&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;&apos;a&#xA0;MoreLabels.Map.S.t&#xA0;-&gt;&#xA0;&apos;b&#xA0;MoreLabels.Map.S.t
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_MoreLabels.Map.html
+++ b/src/pages/api/type_MoreLabels.Map.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;module&#xA0;type&#xA0;OrderedType&#xA0;=&#xA0;Map.OrderedType
 &#xA0;&#xA0;module&#xA0;type&#xA0;S&#xA0;=
 &#xA0;&#xA0;&#xA0;&#xA0;sig
@@ -94,4 +94,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;map&#xA0;:&#xA0;f:(&apos;a&#xA0;-&gt;&#xA0;&apos;b)&#xA0;-&gt;&#xA0;&apos;a&#xA0;t&#xA0;-&gt;&#xA0;&apos;b&#xA0;t
 &#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;mapi&#xA0;:&#xA0;f:(key&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;&apos;b)&#xA0;-&gt;&#xA0;&apos;a&#xA0;t&#xA0;-&gt;&#xA0;&apos;b&#xA0;t
 &#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;end
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_MoreLabels.Set.Make.html
+++ b/src/pages/api/type_MoreLabels.Set.Make.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">functor&#xA0;(Ord&#xA0;:&#xA0;OrderedType)&#xA0;-&gt;
+<div class="ocamldoc"><pre>functor&#xA0;(Ord&#xA0;:&#xA0;OrderedType)&#xA0;-&gt;
+
 &#xA0;&#xA0;sig
 &#xA0;&#xA0;&#xA0;&#xA0;type&#xA0;elt&#xA0;=&#xA0;Ord.t
 &#xA0;&#xA0;&#xA0;&#xA0;and&#xA0;t
@@ -29,4 +29,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;split&#xA0;:&#xA0;elt&#xA0;-&gt;&#xA0;t&#xA0;-&gt;&#xA0;t&#xA0;*&#xA0;bool&#xA0;*&#xA0;t
 &#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;find&#xA0;:&#xA0;elt&#xA0;-&gt;&#xA0;t&#xA0;-&gt;&#xA0;elt
 &#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;of_list&#xA0;:&#xA0;elt&#xA0;list&#xA0;-&gt;&#xA0;t
-&#xA0;&#xA0;end</code></div>
+&#xA0;&#xA0;end</pre></div>

--- a/src/pages/api/type_MoreLabels.Set.OrderedType.html
+++ b/src/pages/api/type_MoreLabels.Set.OrderedType.html
@@ -1,2 +1,1 @@
-<div class="ocamldoc">
-<code class="code">Set.OrderedType</code></div>
+<div class="ocamldoc"><pre>Set.OrderedType</pre></div>

--- a/src/pages/api/type_MoreLabels.Set.S.html
+++ b/src/pages/api/type_MoreLabels.Set.S.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;elt
 &#xA0;&#xA0;and&#xA0;t
 &#xA0;&#xA0;val&#xA0;empty&#xA0;:&#xA0;MoreLabels.Set.S.t
@@ -39,4 +39,4 @@
 &#xA0;&#xA0;val&#xA0;find&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;MoreLabels.Set.S.elt&#xA0;-&gt;&#xA0;MoreLabels.Set.S.t&#xA0;-&gt;&#xA0;MoreLabels.Set.S.elt
 &#xA0;&#xA0;val&#xA0;of_list&#xA0;:&#xA0;MoreLabels.Set.S.elt&#xA0;list&#xA0;-&gt;&#xA0;MoreLabels.Set.S.t
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_MoreLabels.Set.html
+++ b/src/pages/api/type_MoreLabels.Set.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;module&#xA0;type&#xA0;OrderedType&#xA0;=&#xA0;Set.OrderedType
 &#xA0;&#xA0;module&#xA0;type&#xA0;S&#xA0;=
 &#xA0;&#xA0;&#xA0;&#xA0;sig
@@ -81,4 +81,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;find&#xA0;:&#xA0;elt&#xA0;-&gt;&#xA0;t&#xA0;-&gt;&#xA0;elt
 &#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;of_list&#xA0;:&#xA0;elt&#xA0;list&#xA0;-&gt;&#xA0;t
 &#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;end
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_MoreLabels.html
+++ b/src/pages/api/type_MoreLabels.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;module&#xA0;Hashtbl&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;sig
 &#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;type&#xA0;(&apos;a,&#xA0;&apos;b)&#xA0;t&#xA0;=&#xA0;(&apos;a,&#xA0;&apos;b)&#xA0;Hashtbl.t
@@ -330,4 +330,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;of_list&#xA0;:&#xA0;elt&#xA0;list&#xA0;-&gt;&#xA0;t
 &#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;end
 &#xA0;&#xA0;&#xA0;&#xA0;end
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Nativeint.html
+++ b/src/pages/api/type_Nativeint.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;zero&#xA0;:&#xA0;nativeint
 &#xA0;&#xA0;val&#xA0;one&#xA0;:&#xA0;nativeint
 &#xA0;&#xA0;val&#xA0;minus_one&#xA0;:&#xA0;nativeint
@@ -34,4 +34,4 @@
 &#xA0;&#xA0;type&#xA0;t&#xA0;=&#xA0;nativeint
 &#xA0;&#xA0;val&#xA0;compare&#xA0;:&#xA0;Nativeint.t&#xA0;-&gt;&#xA0;Nativeint.t&#xA0;-&gt;&#xA0;int
 &#xA0;&#xA0;external&#xA0;format&#xA0;:&#xA0;string&#xA0;-&gt;&#xA0;nativeint&#xA0;-&gt;&#xA0;string&#xA0;=&#xA0;&quot;caml_nativeint_format&quot;
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Num.html
+++ b/src/pages/api/type_Num.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;num&#xA0;=&#xA0;Int&#xA0;of&#xA0;int&#xA0;|&#xA0;Big_int&#xA0;of&#xA0;Big_int.big_int&#xA0;|&#xA0;Ratio&#xA0;of&#xA0;Ratio.ratio
 &#xA0;&#xA0;val&#xA0;(&#xA0;+/&#xA0;)&#xA0;:&#xA0;Num.num&#xA0;-&gt;&#xA0;Num.num&#xA0;-&gt;&#xA0;Num.num
 &#xA0;&#xA0;val&#xA0;add_num&#xA0;:&#xA0;Num.num&#xA0;-&gt;&#xA0;Num.num&#xA0;-&gt;&#xA0;Num.num
@@ -53,4 +53,4 @@
 &#xA0;&#xA0;val&#xA0;ratio_of_num&#xA0;:&#xA0;Num.num&#xA0;-&gt;&#xA0;Ratio.ratio
 &#xA0;&#xA0;val&#xA0;num_of_ratio&#xA0;:&#xA0;Ratio.ratio&#xA0;-&gt;&#xA0;Num.num
 &#xA0;&#xA0;val&#xA0;float_of_num&#xA0;:&#xA0;Num.num&#xA0;-&gt;&#xA0;float
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Obj.html
+++ b/src/pages/api/type_Obj.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;t
 &#xA0;&#xA0;external&#xA0;repr&#xA0;:&#xA0;&apos;a&#xA0;-&gt;&#xA0;Obj.t&#xA0;=&#xA0;&quot;%identity&quot;
 &#xA0;&#xA0;external&#xA0;obj&#xA0;:&#xA0;Obj.t&#xA0;-&gt;&#xA0;&apos;a&#xA0;=&#xA0;&quot;%identity&quot;
@@ -39,4 +39,4 @@
 &#xA0;&#xA0;val&#xA0;extension_slot&#xA0;:&#xA0;&apos;a&#xA0;-&gt;&#xA0;Obj.t
 &#xA0;&#xA0;val&#xA0;marshal&#xA0;:&#xA0;Obj.t&#xA0;-&gt;&#xA0;bytes
 &#xA0;&#xA0;val&#xA0;unmarshal&#xA0;:&#xA0;bytes&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;Obj.t&#xA0;*&#xA0;int
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Oo.html
+++ b/src/pages/api/type_Oo.html
@@ -1,7 +1,7 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;copy&#xA0;:&#xA0;(&lt;&#xA0;..&#xA0;&gt;&#xA0;as&#xA0;&apos;a)&#xA0;-&gt;&#xA0;&apos;a
 &#xA0;&#xA0;external&#xA0;id&#xA0;:&#xA0;&lt;&#xA0;..&#xA0;&gt;&#xA0;-&gt;&#xA0;int&#xA0;=&#xA0;&quot;%field1&quot;
 &#xA0;&#xA0;val&#xA0;new_method&#xA0;:&#xA0;string&#xA0;-&gt;&#xA0;CamlinternalOO.tag
 &#xA0;&#xA0;val&#xA0;public_method_label&#xA0;:&#xA0;string&#xA0;-&gt;&#xA0;CamlinternalOO.tag
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Parse.html
+++ b/src/pages/api/type_Parse.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;implementation&#xA0;:&#xA0;Lexing.lexbuf&#xA0;-&gt;&#xA0;Parsetree.structure
 &#xA0;&#xA0;val&#xA0;interface&#xA0;:&#xA0;Lexing.lexbuf&#xA0;-&gt;&#xA0;Parsetree.signature
 &#xA0;&#xA0;val&#xA0;toplevel_phrase&#xA0;:&#xA0;Lexing.lexbuf&#xA0;-&gt;&#xA0;Parsetree.toplevel_phrase
@@ -7,4 +7,4 @@
 &#xA0;&#xA0;val&#xA0;core_type&#xA0;:&#xA0;Lexing.lexbuf&#xA0;-&gt;&#xA0;Parsetree.core_type
 &#xA0;&#xA0;val&#xA0;expression&#xA0;:&#xA0;Lexing.lexbuf&#xA0;-&gt;&#xA0;Parsetree.expression
 &#xA0;&#xA0;val&#xA0;pattern&#xA0;:&#xA0;Lexing.lexbuf&#xA0;-&gt;&#xA0;Parsetree.pattern
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Parser.html
+++ b/src/pages/api/type_Parser.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;token&#xA0;=
 &#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;AMPERAMPER
 &#xA0;&#xA0;&#xA0;&#xA0;|&#xA0;AMPERSAND
@@ -138,4 +138,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;(Lexing.lexbuf&#xA0;-&gt;&#xA0;Parser.token)&#xA0;-&gt;&#xA0;Lexing.lexbuf&#xA0;-&gt;&#xA0;Parsetree.expression
 &#xA0;&#xA0;val&#xA0;parse_pattern&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;(Lexing.lexbuf&#xA0;-&gt;&#xA0;Parser.token)&#xA0;-&gt;&#xA0;Lexing.lexbuf&#xA0;-&gt;&#xA0;Parsetree.pattern
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Parsetree.html
+++ b/src/pages/api/type_Parsetree.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;attribute&#xA0;=&#xA0;string&#xA0;Asttypes.loc&#xA0;*&#xA0;Parsetree.payload
 &#xA0;&#xA0;and&#xA0;extension&#xA0;=&#xA0;string&#xA0;Asttypes.loc&#xA0;*&#xA0;Parsetree.payload
 &#xA0;&#xA0;and&#xA0;attributes&#xA0;=&#xA0;Parsetree.attribute&#xA0;list
@@ -371,4 +371,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;|&#xA0;Pdir_int&#xA0;of&#xA0;int
 &#xA0;&#xA0;&#xA0;&#xA0;|&#xA0;Pdir_ident&#xA0;of&#xA0;Longident.t
 &#xA0;&#xA0;&#xA0;&#xA0;|&#xA0;Pdir_bool&#xA0;of&#xA0;bool
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Parsing.html
+++ b/src/pages/api/type_Parsing.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;symbol_start&#xA0;:&#xA0;unit&#xA0;-&gt;&#xA0;int
 &#xA0;&#xA0;val&#xA0;symbol_end&#xA0;:&#xA0;unit&#xA0;-&gt;&#xA0;int
 &#xA0;&#xA0;val&#xA0;rhs_start&#xA0;:&#xA0;int&#xA0;-&gt;&#xA0;int
@@ -37,4 +37,4 @@
 &#xA0;&#xA0;val&#xA0;peek_val&#xA0;:&#xA0;Parsing.parser_env&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;&apos;a
 &#xA0;&#xA0;val&#xA0;is_current_lookahead&#xA0;:&#xA0;&apos;a&#xA0;-&gt;&#xA0;bool
 &#xA0;&#xA0;val&#xA0;parse_error&#xA0;:&#xA0;string&#xA0;-&gt;&#xA0;unit
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Pervasives.LargeFile.html
+++ b/src/pages/api/type_Pervasives.LargeFile.html
@@ -1,9 +1,9 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;seek_out&#xA0;:&#xA0;Pervasives.out_channel&#xA0;-&gt;&#xA0;int64&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;val&#xA0;pos_out&#xA0;:&#xA0;Pervasives.out_channel&#xA0;-&gt;&#xA0;int64
 &#xA0;&#xA0;val&#xA0;out_channel_length&#xA0;:&#xA0;Pervasives.out_channel&#xA0;-&gt;&#xA0;int64
 &#xA0;&#xA0;val&#xA0;seek_in&#xA0;:&#xA0;Pervasives.in_channel&#xA0;-&gt;&#xA0;int64&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;val&#xA0;pos_in&#xA0;:&#xA0;Pervasives.in_channel&#xA0;-&gt;&#xA0;int64
 &#xA0;&#xA0;val&#xA0;in_channel_length&#xA0;:&#xA0;Pervasives.in_channel&#xA0;-&gt;&#xA0;int64
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Pervasives.html
+++ b/src/pages/api/type_Pervasives.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;external&#xA0;raise&#xA0;:&#xA0;exn&#xA0;-&gt;&#xA0;&apos;a&#xA0;=&#xA0;&quot;%raise&quot;
 &#xA0;&#xA0;external&#xA0;raise_notrace&#xA0;:&#xA0;exn&#xA0;-&gt;&#xA0;&apos;a&#xA0;=&#xA0;&quot;%raise_notrace&quot;
 &#xA0;&#xA0;val&#xA0;invalid_arg&#xA0;:&#xA0;string&#xA0;-&gt;&#xA0;&apos;a
@@ -218,4 +218,4 @@
 &#xA0;&#xA0;val&#xA0;unsafe_really_input&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;Pervasives.in_channel&#xA0;-&gt;&#xA0;bytes&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;val&#xA0;do_at_exit&#xA0;:&#xA0;unit&#xA0;-&gt;&#xA0;unit
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Pprintast.html
+++ b/src/pages/api/type_Pprintast.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;space_formatter&#xA0;=&#xA0;(unit,&#xA0;Format.formatter,&#xA0;unit)&#xA0;Pervasives.format
 &#xA0;&#xA0;class&#xA0;printer&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;unit&#xA0;-&gt;
@@ -130,4 +130,4 @@
 &#xA0;&#xA0;val&#xA0;signature&#xA0;:&#xA0;Format.formatter&#xA0;-&gt;&#xA0;Parsetree.signature&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;val&#xA0;structure&#xA0;:&#xA0;Format.formatter&#xA0;-&gt;&#xA0;Parsetree.structure&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;val&#xA0;string_of_structure&#xA0;:&#xA0;Parsetree.structure&#xA0;-&gt;&#xA0;string
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Pprintast.printer.html
+++ b/src/pages/api/type_Pprintast.printer.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">unit&#xA0;-&gt;
+<div class="ocamldoc"><pre>unit&#xA0;-&gt;
+
 object&#xA0;(&apos;b)
 &#xA0;&#xA0;val&#xA0;pipe&#xA0;:&#xA0;bool
 &#xA0;&#xA0;val&#xA0;semi&#xA0;:&#xA0;bool
@@ -109,4 +109,4 @@ object&#xA0;(&apos;b)
 &#xA0;&#xA0;method&#xA0;value_description&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;Format.formatter&#xA0;-&gt;&#xA0;Parsetree.value_description&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;method&#xA0;virtual_flag&#xA0;:&#xA0;Format.formatter&#xA0;-&gt;&#xA0;Asttypes.virtual_flag&#xA0;-&gt;&#xA0;unit
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Printast.html
+++ b/src/pages/api/type_Printast.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;interface&#xA0;:&#xA0;Format.formatter&#xA0;-&gt;&#xA0;Parsetree.signature_item&#xA0;list&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;val&#xA0;implementation&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;Format.formatter&#xA0;-&gt;&#xA0;Parsetree.structure_item&#xA0;list&#xA0;-&gt;&#xA0;unit
@@ -7,4 +7,4 @@
 &#xA0;&#xA0;val&#xA0;expression&#xA0;:&#xA0;int&#xA0;-&gt;&#xA0;Format.formatter&#xA0;-&gt;&#xA0;Parsetree.expression&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;val&#xA0;structure&#xA0;:&#xA0;int&#xA0;-&gt;&#xA0;Format.formatter&#xA0;-&gt;&#xA0;Parsetree.structure&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;val&#xA0;payload&#xA0;:&#xA0;int&#xA0;-&gt;&#xA0;Format.formatter&#xA0;-&gt;&#xA0;Parsetree.payload&#xA0;-&gt;&#xA0;unit
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Printexc.Slot.html
+++ b/src/pages/api/type_Printexc.Slot.html
@@ -1,7 +1,7 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;t&#xA0;=&#xA0;Printexc.backtrace_slot
 &#xA0;&#xA0;val&#xA0;is_raise&#xA0;:&#xA0;Printexc.Slot.t&#xA0;-&gt;&#xA0;bool
 &#xA0;&#xA0;val&#xA0;location&#xA0;:&#xA0;Printexc.Slot.t&#xA0;-&gt;&#xA0;Printexc.location&#xA0;option
 &#xA0;&#xA0;val&#xA0;format&#xA0;:&#xA0;int&#xA0;-&gt;&#xA0;Printexc.Slot.t&#xA0;-&gt;&#xA0;string&#xA0;option
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Printexc.html
+++ b/src/pages/api/type_Printexc.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;to_string&#xA0;:&#xA0;exn&#xA0;-&gt;&#xA0;string
 &#xA0;&#xA0;val&#xA0;print&#xA0;:&#xA0;(&apos;a&#xA0;-&gt;&#xA0;&apos;b)&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;&apos;b
 &#xA0;&#xA0;val&#xA0;catch&#xA0;:&#xA0;(&apos;a&#xA0;-&gt;&#xA0;&apos;b)&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;&apos;b
@@ -40,4 +40,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;Printexc.raw_backtrace_slot&#xA0;-&gt;&#xA0;Printexc.backtrace_slot
 &#xA0;&#xA0;val&#xA0;exn_slot_id&#xA0;:&#xA0;exn&#xA0;-&gt;&#xA0;int
 &#xA0;&#xA0;val&#xA0;exn_slot_name&#xA0;:&#xA0;exn&#xA0;-&gt;&#xA0;string
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Printf.html
+++ b/src/pages/api/type_Printf.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;fprintf&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;Pervasives.out_channel&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;(&apos;a,&#xA0;Pervasives.out_channel,&#xA0;unit)&#xA0;Pervasives.format&#xA0;-&gt;&#xA0;&apos;a
@@ -23,4 +23,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;Buffer.t&#xA0;-&gt;&#xA0;(&apos;b,&#xA0;Buffer.t,&#xA0;unit,&#xA0;&apos;a)&#xA0;Pervasives.format4&#xA0;-&gt;&#xA0;&apos;b
 &#xA0;&#xA0;val&#xA0;kprintf&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;(string&#xA0;-&gt;&#xA0;&apos;a)&#xA0;-&gt;&#xA0;(&apos;b,&#xA0;unit,&#xA0;string,&#xA0;&apos;a)&#xA0;Pervasives.format4&#xA0;-&gt;&#xA0;&apos;b
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Queue.html
+++ b/src/pages/api/type_Queue.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;&apos;a&#xA0;t
 &#xA0;&#xA0;exception&#xA0;Empty
 &#xA0;&#xA0;val&#xA0;create&#xA0;:&#xA0;unit&#xA0;-&gt;&#xA0;&apos;a&#xA0;Queue.t
@@ -16,4 +16,4 @@
 &#xA0;&#xA0;val&#xA0;iter&#xA0;:&#xA0;(&apos;a&#xA0;-&gt;&#xA0;unit)&#xA0;-&gt;&#xA0;&apos;a&#xA0;Queue.t&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;val&#xA0;fold&#xA0;:&#xA0;(&apos;b&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;&apos;b)&#xA0;-&gt;&#xA0;&apos;b&#xA0;-&gt;&#xA0;&apos;a&#xA0;Queue.t&#xA0;-&gt;&#xA0;&apos;b
 &#xA0;&#xA0;val&#xA0;transfer&#xA0;:&#xA0;&apos;a&#xA0;Queue.t&#xA0;-&gt;&#xA0;&apos;a&#xA0;Queue.t&#xA0;-&gt;&#xA0;unit
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Random.State.html
+++ b/src/pages/api/type_Random.State.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;t
 &#xA0;&#xA0;val&#xA0;make&#xA0;:&#xA0;int&#xA0;array&#xA0;-&gt;&#xA0;Random.State.t
 &#xA0;&#xA0;val&#xA0;make_self_init&#xA0;:&#xA0;unit&#xA0;-&gt;&#xA0;Random.State.t
@@ -11,4 +11,4 @@
 &#xA0;&#xA0;val&#xA0;int64&#xA0;:&#xA0;Random.State.t&#xA0;-&gt;&#xA0;Int64.t&#xA0;-&gt;&#xA0;Int64.t
 &#xA0;&#xA0;val&#xA0;float&#xA0;:&#xA0;Random.State.t&#xA0;-&gt;&#xA0;float&#xA0;-&gt;&#xA0;float
 &#xA0;&#xA0;val&#xA0;bool&#xA0;:&#xA0;Random.State.t&#xA0;-&gt;&#xA0;bool
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Random.html
+++ b/src/pages/api/type_Random.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;init&#xA0;:&#xA0;int&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;val&#xA0;full_init&#xA0;:&#xA0;int&#xA0;array&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;val&#xA0;self_init&#xA0;:&#xA0;unit&#xA0;-&gt;&#xA0;unit
@@ -26,4 +26,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;end
 &#xA0;&#xA0;val&#xA0;get_state&#xA0;:&#xA0;unit&#xA0;-&gt;&#xA0;Random.State.t
 &#xA0;&#xA0;val&#xA0;set_state&#xA0;:&#xA0;Random.State.t&#xA0;-&gt;&#xA0;unit
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Scanf.Scanning.html
+++ b/src/pages/api/type_Scanf.Scanning.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;in_channel
 &#xA0;&#xA0;type&#xA0;scanbuf&#xA0;=&#xA0;Scanf.Scanning.in_channel
 &#xA0;&#xA0;val&#xA0;stdin&#xA0;:&#xA0;Scanf.Scanning.in_channel
@@ -16,4 +16,4 @@
 &#xA0;&#xA0;val&#xA0;beginning_of_input&#xA0;:&#xA0;Scanf.Scanning.in_channel&#xA0;-&gt;&#xA0;bool
 &#xA0;&#xA0;val&#xA0;name_of_input&#xA0;:&#xA0;Scanf.Scanning.in_channel&#xA0;-&gt;&#xA0;string
 &#xA0;&#xA0;val&#xA0;stdib&#xA0;:&#xA0;Scanf.Scanning.in_channel
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Scanf.html
+++ b/src/pages/api/type_Scanf.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;module&#xA0;Scanning&#xA0;:
 &#xA0;&#xA0;&#xA0;&#xA0;sig
 &#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;type&#xA0;in_channel
@@ -52,4 +52,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;(&apos;a,&#xA0;&apos;b,&#xA0;&apos;c,&#xA0;&apos;d,&#xA0;&apos;e,&#xA0;&apos;f)&#xA0;Pervasives.format6&#xA0;-&gt;
 &#xA0;&#xA0;&#xA0;&#xA0;(&apos;a,&#xA0;&apos;b,&#xA0;&apos;c,&#xA0;&apos;d,&#xA0;&apos;e,&#xA0;&apos;f)&#xA0;Pervasives.format6
 &#xA0;&#xA0;val&#xA0;unescaped&#xA0;:&#xA0;string&#xA0;-&gt;&#xA0;string
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Set.Make.html
+++ b/src/pages/api/type_Set.Make.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">functor&#xA0;(Ord&#xA0;:&#xA0;OrderedType)&#xA0;-&gt;
+<div class="ocamldoc"><pre>functor&#xA0;(Ord&#xA0;:&#xA0;OrderedType)&#xA0;-&gt;
+
 &#xA0;&#xA0;sig
 &#xA0;&#xA0;&#xA0;&#xA0;type&#xA0;elt&#xA0;=&#xA0;Ord.t
 &#xA0;&#xA0;&#xA0;&#xA0;type&#xA0;t
@@ -29,4 +29,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;split&#xA0;:&#xA0;elt&#xA0;-&gt;&#xA0;t&#xA0;-&gt;&#xA0;t&#xA0;*&#xA0;bool&#xA0;*&#xA0;t
 &#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;find&#xA0;:&#xA0;elt&#xA0;-&gt;&#xA0;t&#xA0;-&gt;&#xA0;elt
 &#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;of_list&#xA0;:&#xA0;elt&#xA0;list&#xA0;-&gt;&#xA0;t
-&#xA0;&#xA0;end</code></div>
+&#xA0;&#xA0;end</pre></div>

--- a/src/pages/api/type_Set.OrderedType.html
+++ b/src/pages/api/type_Set.OrderedType.html
@@ -1,2 +1,1 @@
-<div class="ocamldoc">
-<code class="code">sig&#xA0;type&#xA0;t&#xA0;val&#xA0;compare&#xA0;:&#xA0;Set.OrderedType.t&#xA0;-&gt;&#xA0;Set.OrderedType.t&#xA0;-&gt;&#xA0;int&#xA0;end</code></div>
+<div class="ocamldoc"><pre>sig&#xA0;type&#xA0;t&#xA0;val&#xA0;compare&#xA0;:&#xA0;Set.OrderedType.t&#xA0;-&gt;&#xA0;Set.OrderedType.t&#xA0;-&gt;&#xA0;int&#xA0;end</pre></div>

--- a/src/pages/api/type_Set.S.html
+++ b/src/pages/api/type_Set.S.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;elt
 &#xA0;&#xA0;type&#xA0;t
 &#xA0;&#xA0;val&#xA0;empty&#xA0;:&#xA0;Set.S.t
@@ -28,4 +28,4 @@
 &#xA0;&#xA0;val&#xA0;split&#xA0;:&#xA0;Set.S.elt&#xA0;-&gt;&#xA0;Set.S.t&#xA0;-&gt;&#xA0;Set.S.t&#xA0;*&#xA0;bool&#xA0;*&#xA0;Set.S.t
 &#xA0;&#xA0;val&#xA0;find&#xA0;:&#xA0;Set.S.elt&#xA0;-&gt;&#xA0;Set.S.t&#xA0;-&gt;&#xA0;Set.S.elt
 &#xA0;&#xA0;val&#xA0;of_list&#xA0;:&#xA0;Set.S.elt&#xA0;list&#xA0;-&gt;&#xA0;Set.S.t
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Set.html
+++ b/src/pages/api/type_Set.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;module&#xA0;type&#xA0;OrderedType&#xA0;=
 &#xA0;&#xA0;&#xA0;&#xA0;sig
 &#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;type&#xA0;t
@@ -68,4 +68,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;find&#xA0;:&#xA0;elt&#xA0;-&gt;&#xA0;t&#xA0;-&gt;&#xA0;elt
 &#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;of_list&#xA0;:&#xA0;elt&#xA0;list&#xA0;-&gt;&#xA0;t
 &#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;end
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Sort.html
+++ b/src/pages/api/type_Sort.html
@@ -1,6 +1,6 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;list&#xA0;:&#xA0;(&apos;a&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;bool)&#xA0;-&gt;&#xA0;&apos;a&#xA0;list&#xA0;-&gt;&#xA0;&apos;a&#xA0;list
 &#xA0;&#xA0;val&#xA0;array&#xA0;:&#xA0;(&apos;a&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;bool)&#xA0;-&gt;&#xA0;&apos;a&#xA0;array&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;val&#xA0;merge&#xA0;:&#xA0;(&apos;a&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;bool)&#xA0;-&gt;&#xA0;&apos;a&#xA0;list&#xA0;-&gt;&#xA0;&apos;a&#xA0;list&#xA0;-&gt;&#xA0;&apos;a&#xA0;list
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Stack.html
+++ b/src/pages/api/type_Stack.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;&apos;a&#xA0;t
 &#xA0;&#xA0;exception&#xA0;Empty
 &#xA0;&#xA0;val&#xA0;create&#xA0;:&#xA0;unit&#xA0;-&gt;&#xA0;&apos;a&#xA0;Stack.t
@@ -11,4 +11,4 @@
 &#xA0;&#xA0;val&#xA0;is_empty&#xA0;:&#xA0;&apos;a&#xA0;Stack.t&#xA0;-&gt;&#xA0;bool
 &#xA0;&#xA0;val&#xA0;length&#xA0;:&#xA0;&apos;a&#xA0;Stack.t&#xA0;-&gt;&#xA0;int
 &#xA0;&#xA0;val&#xA0;iter&#xA0;:&#xA0;(&apos;a&#xA0;-&gt;&#xA0;unit)&#xA0;-&gt;&#xA0;&apos;a&#xA0;Stack.t&#xA0;-&gt;&#xA0;unit
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_StdLabels.Array.html
+++ b/src/pages/api/type_StdLabels.Array.html
@@ -1,2 +1,1 @@
-<div class="ocamldoc">
-<code class="code">(module&#xA0;ArrayLabels)</code></div>
+<div class="ocamldoc"><pre>(module&#xA0;ArrayLabels)</pre></div>

--- a/src/pages/api/type_StdLabels.Bytes.html
+++ b/src/pages/api/type_StdLabels.Bytes.html
@@ -1,2 +1,1 @@
-<div class="ocamldoc">
-<code class="code">(module&#xA0;BytesLabels)</code></div>
+<div class="ocamldoc"><pre>(module&#xA0;BytesLabels)</pre></div>

--- a/src/pages/api/type_StdLabels.List.html
+++ b/src/pages/api/type_StdLabels.List.html
@@ -1,2 +1,1 @@
-<div class="ocamldoc">
-<code class="code">(module&#xA0;ListLabels)</code></div>
+<div class="ocamldoc"><pre>(module&#xA0;ListLabels)</pre></div>

--- a/src/pages/api/type_StdLabels.String.html
+++ b/src/pages/api/type_StdLabels.String.html
@@ -1,2 +1,1 @@
-<div class="ocamldoc">
-<code class="code">(module&#xA0;StringLabels)</code></div>
+<div class="ocamldoc"><pre>(module&#xA0;StringLabels)</pre></div>

--- a/src/pages/api/type_StdLabels.html
+++ b/src/pages/api/type_StdLabels.html
@@ -1,7 +1,7 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;module&#xA0;Array&#xA0;=&#xA0;ArrayLabels
 &#xA0;&#xA0;module&#xA0;Bytes&#xA0;=&#xA0;BytesLabels
 &#xA0;&#xA0;module&#xA0;List&#xA0;=&#xA0;ListLabels
 &#xA0;&#xA0;module&#xA0;String&#xA0;=&#xA0;StringLabels
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Str.html
+++ b/src/pages/api/type_Str.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;regexp
 &#xA0;&#xA0;val&#xA0;regexp&#xA0;:&#xA0;string&#xA0;-&gt;&#xA0;Str.regexp
 &#xA0;&#xA0;val&#xA0;regexp_case_fold&#xA0;:&#xA0;string&#xA0;-&gt;&#xA0;Str.regexp
@@ -34,4 +34,4 @@
 &#xA0;&#xA0;val&#xA0;string_after&#xA0;:&#xA0;string&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;string
 &#xA0;&#xA0;val&#xA0;first_chars&#xA0;:&#xA0;string&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;string
 &#xA0;&#xA0;val&#xA0;last_chars&#xA0;:&#xA0;string&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;string
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Stream.html
+++ b/src/pages/api/type_Stream.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;&apos;a&#xA0;t
 &#xA0;&#xA0;exception&#xA0;Failure
 &#xA0;&#xA0;exception&#xA0;Error&#xA0;of&#xA0;string
@@ -24,4 +24,4 @@
 &#xA0;&#xA0;val&#xA0;sempty&#xA0;:&#xA0;&apos;a&#xA0;Stream.t
 &#xA0;&#xA0;val&#xA0;slazy&#xA0;:&#xA0;(unit&#xA0;-&gt;&#xA0;&apos;a&#xA0;Stream.t)&#xA0;-&gt;&#xA0;&apos;a&#xA0;Stream.t
 &#xA0;&#xA0;val&#xA0;dump&#xA0;:&#xA0;(&apos;a&#xA0;-&gt;&#xA0;unit)&#xA0;-&gt;&#xA0;&apos;a&#xA0;Stream.t&#xA0;-&gt;&#xA0;unit
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_String.html
+++ b/src/pages/api/type_String.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;external&#xA0;length&#xA0;:&#xA0;string&#xA0;-&gt;&#xA0;int&#xA0;=&#xA0;&quot;%string_length&quot;
 &#xA0;&#xA0;external&#xA0;get&#xA0;:&#xA0;string&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;char&#xA0;=&#xA0;&quot;%string_safe_get&quot;
 &#xA0;&#xA0;external&#xA0;set&#xA0;:&#xA0;bytes&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;char&#xA0;-&gt;&#xA0;unit&#xA0;=&#xA0;&quot;%string_safe_set&quot;
@@ -36,4 +36,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;=&#xA0;&quot;caml_blit_string&quot;&#xA0;&quot;noalloc&quot;
 &#xA0;&#xA0;external&#xA0;unsafe_fill&#xA0;:&#xA0;bytes&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;char&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;&#xA0;&#xA0;=&#xA0;&quot;caml_fill_string&quot;&#xA0;&quot;noalloc&quot;
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_StringLabels.html
+++ b/src/pages/api/type_StringLabels.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;external&#xA0;length&#xA0;:&#xA0;string&#xA0;-&gt;&#xA0;int&#xA0;=&#xA0;&quot;%string_length&quot;
 &#xA0;&#xA0;external&#xA0;get&#xA0;:&#xA0;string&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;char&#xA0;=&#xA0;&quot;%string_safe_get&quot;
 &#xA0;&#xA0;external&#xA0;set&#xA0;:&#xA0;bytes&#xA0;-&gt;&#xA0;int&#xA0;-&gt;&#xA0;char&#xA0;-&gt;&#xA0;unit&#xA0;=&#xA0;&quot;%string_safe_set&quot;
@@ -38,4 +38,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;=&#xA0;&quot;caml_blit_string&quot;&#xA0;&quot;noalloc&quot;
 &#xA0;&#xA0;external&#xA0;unsafe_fill&#xA0;:&#xA0;bytes&#xA0;-&gt;&#xA0;pos:int&#xA0;-&gt;&#xA0;len:int&#xA0;-&gt;&#xA0;char&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;&#xA0;&#xA0;=&#xA0;&quot;caml_fill_string&quot;&#xA0;&quot;noalloc&quot;
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Syntaxerr.html
+++ b/src/pages/api/type_Syntaxerr.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;error&#xA0;=
 &#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;Unclosed&#xA0;of&#xA0;Location.t&#xA0;*&#xA0;string&#xA0;*&#xA0;Location.t&#xA0;*&#xA0;string
 &#xA0;&#xA0;&#xA0;&#xA0;|&#xA0;Expecting&#xA0;of&#xA0;Location.t&#xA0;*&#xA0;string
@@ -13,4 +13,4 @@
 &#xA0;&#xA0;val&#xA0;report_error&#xA0;:&#xA0;Format.formatter&#xA0;-&gt;&#xA0;Syntaxerr.error&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;val&#xA0;location_of_error&#xA0;:&#xA0;Syntaxerr.error&#xA0;-&gt;&#xA0;Location.t
 &#xA0;&#xA0;val&#xA0;ill_formed_ast&#xA0;:&#xA0;Location.t&#xA0;-&gt;&#xA0;string&#xA0;-&gt;&#xA0;&apos;a
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Sys.html
+++ b/src/pages/api/type_Sys.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;argv&#xA0;:&#xA0;string&#xA0;array
 &#xA0;&#xA0;val&#xA0;executable_name&#xA0;:&#xA0;string
 &#xA0;&#xA0;external&#xA0;file_exists&#xA0;:&#xA0;string&#xA0;-&gt;&#xA0;bool&#xA0;=&#xA0;&quot;caml_sys_file_exists&quot;
@@ -52,4 +52,4 @@
 &#xA0;&#xA0;exception&#xA0;Break
 &#xA0;&#xA0;val&#xA0;catch_break&#xA0;:&#xA0;bool&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;val&#xA0;ocaml_version&#xA0;:&#xA0;string
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Unix.LargeFile.html
+++ b/src/pages/api/type_Unix.LargeFile.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;val&#xA0;lseek&#xA0;:&#xA0;Unix.file_descr&#xA0;-&gt;&#xA0;int64&#xA0;-&gt;&#xA0;Unix.seek_command&#xA0;-&gt;&#xA0;int64
 &#xA0;&#xA0;val&#xA0;truncate&#xA0;:&#xA0;string&#xA0;-&gt;&#xA0;int64&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;val&#xA0;ftruncate&#xA0;:&#xA0;Unix.file_descr&#xA0;-&gt;&#xA0;int64&#xA0;-&gt;&#xA0;unit
@@ -20,4 +20,4 @@
 &#xA0;&#xA0;val&#xA0;stat&#xA0;:&#xA0;string&#xA0;-&gt;&#xA0;Unix.LargeFile.stats
 &#xA0;&#xA0;val&#xA0;lstat&#xA0;:&#xA0;string&#xA0;-&gt;&#xA0;Unix.LargeFile.stats
 &#xA0;&#xA0;val&#xA0;fstat&#xA0;:&#xA0;Unix.file_descr&#xA0;-&gt;&#xA0;Unix.LargeFile.stats
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Unix.html
+++ b/src/pages/api/type_Unix.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;error&#xA0;=
 &#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;E2BIG
 &#xA0;&#xA0;&#xA0;&#xA0;|&#xA0;EACCES
@@ -479,4 +479,4 @@
 &#xA0;&#xA0;type&#xA0;flow_action&#xA0;=&#xA0;TCOOFF&#xA0;|&#xA0;TCOON&#xA0;|&#xA0;TCIOFF&#xA0;|&#xA0;TCION
 &#xA0;&#xA0;val&#xA0;tcflow&#xA0;:&#xA0;Unix.file_descr&#xA0;-&gt;&#xA0;Unix.flow_action&#xA0;-&gt;&#xA0;unit
 &#xA0;&#xA0;val&#xA0;setsid&#xA0;:&#xA0;unit&#xA0;-&gt;&#xA0;int
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Weak.Make.html
+++ b/src/pages/api/type_Weak.Make.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">functor&#xA0;(H&#xA0;:&#xA0;Hashtbl.HashedType)&#xA0;-&gt;
+<div class="ocamldoc"><pre>functor&#xA0;(H&#xA0;:&#xA0;Hashtbl.HashedType)&#xA0;-&gt;
+
 &#xA0;&#xA0;sig
 &#xA0;&#xA0;&#xA0;&#xA0;type&#xA0;data&#xA0;=&#xA0;H.t
 &#xA0;&#xA0;&#xA0;&#xA0;type&#xA0;t
@@ -15,4 +15,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;fold&#xA0;:&#xA0;(data&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;&apos;a)&#xA0;-&gt;&#xA0;t&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;&apos;a
 &#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;count&#xA0;:&#xA0;t&#xA0;-&gt;&#xA0;int
 &#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;stats&#xA0;:&#xA0;t&#xA0;-&gt;&#xA0;int&#xA0;*&#xA0;int&#xA0;*&#xA0;int&#xA0;*&#xA0;int&#xA0;*&#xA0;int&#xA0;*&#xA0;int
-&#xA0;&#xA0;end</code></div>
+&#xA0;&#xA0;end</pre></div>

--- a/src/pages/api/type_Weak.S.html
+++ b/src/pages/api/type_Weak.S.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;data
 &#xA0;&#xA0;type&#xA0;t
 &#xA0;&#xA0;val&#xA0;create&#xA0;:&#xA0;int&#xA0;-&gt;&#xA0;Weak.S.t
@@ -14,4 +14,4 @@
 &#xA0;&#xA0;val&#xA0;fold&#xA0;:&#xA0;(Weak.S.data&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;&apos;a)&#xA0;-&gt;&#xA0;Weak.S.t&#xA0;-&gt;&#xA0;&apos;a&#xA0;-&gt;&#xA0;&apos;a
 &#xA0;&#xA0;val&#xA0;count&#xA0;:&#xA0;Weak.S.t&#xA0;-&gt;&#xA0;int
 &#xA0;&#xA0;val&#xA0;stats&#xA0;:&#xA0;Weak.S.t&#xA0;-&gt;&#xA0;int&#xA0;*&#xA0;int&#xA0;*&#xA0;int&#xA0;*&#xA0;int&#xA0;*&#xA0;int&#xA0;*&#xA0;int
-end</code></div>
+end</pre></div>

--- a/src/pages/api/type_Weak.html
+++ b/src/pages/api/type_Weak.html
@@ -1,5 +1,5 @@
-<div class="ocamldoc">
-<code class="code">sig
+<div class="ocamldoc"><pre>sig
+
 &#xA0;&#xA0;type&#xA0;&apos;a&#xA0;t
 &#xA0;&#xA0;val&#xA0;create&#xA0;:&#xA0;int&#xA0;-&gt;&#xA0;&apos;a&#xA0;Weak.t
 &#xA0;&#xA0;val&#xA0;length&#xA0;:&#xA0;&apos;a&#xA0;Weak.t&#xA0;-&gt;&#xA0;int
@@ -44,4 +44,4 @@
 &#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;count&#xA0;:&#xA0;t&#xA0;-&gt;&#xA0;int
 &#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;val&#xA0;stats&#xA0;:&#xA0;t&#xA0;-&gt;&#xA0;int&#xA0;*&#xA0;int&#xA0;*&#xA0;int&#xA0;*&#xA0;int&#xA0;*&#xA0;int&#xA0;*&#xA0;int
 &#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;end
-end</code></div>
+end</pre></div>


### PR DESCRIPTION
The whitespace on pages like https://reasonml.github.io/api/type_Parsetree.html is not being preserved correctly. Fixed in this PR.

<img width="970" alt="screen shot 2017-07-18 at 10 44 37 pm" src="https://user-images.githubusercontent.com/1232587/28352414-12302696-6c0b-11e7-95af-c68a2e4c7406.png">
