### PR TITLE
Minor changes in data types section

### DIFF
--- a/src/pages/guide/language/data-types.md
+++ b/src/pages/guide/language/data-types.md
@@ -62,7 +62,7 @@ To reduce redundancy, we provide **punning** for a record's types and values. Yo
 type horsePower = {power: int, metric: bool};
 
 let metric = true;
-let horsePower1 = {power: 10, metric};
+let someHorsePower = {power: 10, metric};
 /* same as the value {power: 10, metric: metric}; */
 
 type car = {name: string, horsePower};


### PR DESCRIPTION
I was confused because I read `let horsePower` (my eyes/brain omitted the 1) and so I was confused by the type car below because I was seing a tuple used in the type. Using a more different name for the tuple and the type should avoid this for someone else!