### PR TITLE
bug(QuickStart): Change link to be absolute path

### DIFF
--- a/src/pages/guide/javascript/quickstart.md
+++ b/src/pages/guide/javascript/quickstart.md
@@ -18,6 +18,6 @@ npm run watch
 ```
 This will compile Reason to Javascript in the `lib/js/` folder
 
-Alternatively, **to start a [ReasonReact](https://reasonml.github.io/reason-react/gettingStarted.html) app**, try `bsb -init my-react-app -theme react`.
+Alternatively, **to start a [ReasonReact](//reasonml.github.io/reason-react/gettingStarted.html) app**, try `bsb -init my-react-app -theme react`.
 More info on bsb & bsconfig [here](http://bucklescript.github.io/bucklescript/Manual.html#_bucklescript_build_system_code_bsb_code).
 **BuckleScript has first-class support for Reason**, which is why you don't see any extra "reason" installation.


### PR DESCRIPTION
On the website, it will link to
`https://reasonml.github.io/https://reasonml.github.io/reason-react/gettingStarted.html`
instead of the intended
`https://reasonml.github.io/reason-react/gettingStarted.html`