### PR TITLE
Delete % char

### DIFF
--- a/src/pages/guide/javascript/interop.md
+++ b/src/pages/guide/javascript/interop.md
@@ -9,7 +9,7 @@ If you're just hacking things together, this can be very nice, but you also have
 
 ```ocaml
 Js.log "this is reason";
-[%%bs.raw {|
+[%bs.raw {|
 console.log('here is some javascript for you');
 |}];
 ```


### PR DESCRIPTION
Shouldn't it only be 1 `%`? Other examples only show 1 `%` and there's no explanation on 2 or 1