### PR TITLE
Simplifies MakeSet functor using pointfree style

### DIFF
--- a/src/pages/guide/language/module.md
+++ b/src/pages/guide/language/module.md
@@ -251,7 +251,7 @@ module MakeSet = fun (Item: Comparable) => {
   let empty = [];
   let add (currentSet: backingType) (newItem: Item.t) :backingType =>
     /* if item exists */
-    if (List.exists (fun x => Item.equal x newItem) currentSet) {
+    if (List.exists (Item.equal newItem) currentSet) {
       currentSet /* return the same (immutable) set (a list really) */
     } else {
       [newItem, ...currentSet]; /* prepend to the set and return it */


### PR DESCRIPTION
Removes unnecessary point from Set functor example. Minor trivial simplification of the code.