### PR TITLE
Add description of .cm* files to FAQ

### DIFF
--- a/src/pages/community/faq.md
+++ b/src/pages/community/faq.md
@@ -82,3 +82,18 @@ BuckleScript is optimized for performance across the whole stack. You can try sl
 - Adding a few infinite loops here and there.
 - Stuffing a JavaScript build tool in the pipeline.
 - Dragging in more dependencies for writing a hello world.
+
+### I'm seeing some weird .cm[ixja] files referenced in a compiler error. Where do these files come from?
+
+OCaml outputs a few different files during compilation, depending on your build target (native/bytecode/JavaScript):
+
+.cmi: Compiled interface (.rei/mli) file
+.cmx: Compiled object file for native output (via ocamlopt)
+.cmo: Compiled object file for bytecode output
+.cmj: Compiled object file for web (via BuckleScript)
+.cma: Library file for bytecode output (equivalent to C's .a files)
+.cmxa: Library file for native output
+.cmt: Contains a "Typetree" – basically the AST with all type info
+.cmti: Just like a .cmt file, but for interface files
+
+There is more information and context for some of these files [on the OCaml site](https://ocaml.org/learn/tutorials/filenames.html) and in [this mailing list post](http://caml.inria.fr/pub/ml-archives/caml-list/2008/09/2bc9b38171177af5dc0d832a365d290d.en.html)

--- a/src/pages/community/faq.md
+++ b/src/pages/community/faq.md
@@ -95,5 +95,6 @@ OCaml outputs a few different files during compilation, depending on your build 
 - .cmxa: Library file for native output
 - .cmt: Contains a "Typedtree" – basically the AST with all type info
 - .cmti: Just like a .cmt file, but for interface files
+- .cmxs: Dynamically loaded plugin (for native compilation)
 
-There is more information and context for some of these files [on the OCaml site](https://ocaml.org/learn/tutorials/filenames.html) and in [this mailing list post](http://caml.inria.fr/pub/ml-archives/caml-list/2008/09/2bc9b38171177af5dc0d832a365d290d.en.html)
+There is more information and context for some of these files [on the OCaml site](https://ocaml.org/learn/tutorials/filenames.html) and in [this mailing list post](http://caml.inria.fr/pub/ml-archives/caml-list/2008/09/2bc9b38171177af5dc0d832a365d290d.en.html). There are deeper dives on [native](https://caml.inria.fr/pub/docs/manual-ocaml/native.html) and [bytecode](http://caml.inria.fr/pub/docs/manual-ocaml/comp.html) compilation that contain more detailed descriptions in the OCaml manual

--- a/src/pages/community/faq.md
+++ b/src/pages/community/faq.md
@@ -83,17 +83,17 @@ BuckleScript is optimized for performance across the whole stack. You can try sl
 - Stuffing a JavaScript build tool in the pipeline.
 - Dragging in more dependencies for writing a hello world.
 
-### I'm seeing some weird .cm[ixja] files referenced in a compiler error. Where do these files come from?
+### I'm seeing a weird .cmi/.cmx/.cmj/.cma file referenced in a compiler error. Where do these files come from?
 
 OCaml outputs a few different files during compilation, depending on your build target (native/bytecode/JavaScript):
 
-.cmi: Compiled interface (.rei/mli) file
-.cmx: Compiled object file for native output (via ocamlopt)
-.cmo: Compiled object file for bytecode output
-.cmj: Compiled object file for web (via BuckleScript)
-.cma: Library file for bytecode output (equivalent to C's .a files)
-.cmxa: Library file for native output
-.cmt: Contains a "Typetree" – basically the AST with all type info
-.cmti: Just like a .cmt file, but for interface files
+- .cmi: Compiled interface (.rei/mli) file
+- .cmx: Compiled object file for native output (via ocamlopt)
+- .cmo: Compiled object file for bytecode output
+- .cmj: Compiled object file for web (via BuckleScript)
+- .cma: Library file for bytecode output (equivalent to C's .a files)
+- .cmxa: Library file for native output
+- .cmt: Contains a "Typedtree" – basically the AST with all type info
+- .cmti: Just like a .cmt file, but for interface files
 
 There is more information and context for some of these files [on the OCaml site](https://ocaml.org/learn/tutorials/filenames.html) and in [this mailing list post](http://caml.inria.fr/pub/ml-archives/caml-list/2008/09/2bc9b38171177af5dc0d832a365d290d.en.html)


### PR DESCRIPTION
As a newcomer I found references to these files in compiler/build errors quite cryptic. Not sure if this is the best place to document them but it'd be nice to have this information accessible and searchable.