### PR TITLE
Fix #85, overflow issue on Firefox

### DIFF
--- a/src/pages/try.js
+++ b/src/pages/try.js
@@ -431,6 +431,7 @@ const styles = {
     minHeight: 0,
     border: '1px solid #aaa',
     position: 'relative',
+    overflow: 'auto',
     '@media(max-width: 500px)': {
       // display: 'block',
       height: 300,


### PR DESCRIPTION
Works fine in Chrome. Scrolls label as well in Firefox, so not perfect, but it's a simple hack and much betterer than before!