### PR TITLE
Update quickstart.md

### DIFF
--- a/src/pages/guide/javascript/quickstart.md
+++ b/src/pages/guide/javascript/quickstart.md
@@ -18,7 +18,7 @@ npm run build
 You can also build in watch mode:
 
 ```sh
-npm run watch
+npm run start
 ```
 
 That's all! This compiles Reason to Javascript in the `lib/js/` folder.


### PR DESCRIPTION
Version 1.9 of bsb-platform has the following scripts:

```json
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1",
    "start": "bsb -make-world -w",
    "build": "bsb -make-world" ,
    "webpack": "webpack -w",
    "clean": "bsb -clean-world"
  },
```

So the text should read `npm run start`