### PR TITLE
Various style cleanup/tweaks

### DIFF
--- a/src/components/Features.js
+++ b/src/components/Features.js
@@ -2,6 +2,7 @@ import React from "react"
 import Link from "gatsby-link"
 import Helmet from "react-helmet"
 import {headerFontFamily} from '../utils/typography'
+import { dividerLine } from '../utils/colors'
 
 const intersperse = (items, fn) => items.reduce(
   (items, item, i) => i === 0 ? [item] : [...items, fn(i), item],
@@ -45,7 +46,7 @@ const styles = {
   },
   divider: {
     flexBasis: 1,
-    backgroundColor: '#cecece',
+    backgroundColor: dividerLine,
     margin: '30px 0',
     '@media(max-width: 900px)': {
       margin: 0,

--- a/src/components/GuideSidebar.js
+++ b/src/components/GuideSidebar.js
@@ -2,14 +2,14 @@ import React from 'react'
 import Link from './Link'
 
 import {scale, rhythm, headerFontFamily} from '../utils/typography'
-import {accent} from '../utils/colors'
+import {text, accent, dividerLine} from '../utils/colors'
 
 const GuideSidebar = ({props, current, root, search}) => (
   <div css={styles.container}>
     <div css={styles.contents}>
       <Link css={styles.link} to={search}>
         <svg css={styles.searchIcon} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 15 15">
-          <path d="M6.213 12.548C2.783 12.548 0 9.738 0 6.274 0 2.81 2.782 0 6.213 0c3.432 0 6.214 2.81 6.214 6.274 0 1.358-.428 2.616-1.154 3.643L15 13.482 13.576 15l-3.77-3.606c-1.015.727-2.254 1.154-3.593 1.154zm0-2.09c2.288 0 4.143-1.874 4.143-4.184S8.5 2.09 6.213 2.09c-2.287 0-4.142 1.874-4.142 4.184s1.856 4.183 4.143 4.183z"></path>
+          <path fill={text} d="M6.213 12.548C2.783 12.548 0 9.738 0 6.274 0 2.81 2.782 0 6.213 0c3.432 0 6.214 2.81 6.214 6.274 0 1.358-.428 2.616-1.154 3.643L15 13.482 13.576 15l-3.77-3.606c-1.015.727-2.254 1.154-3.593 1.154zm0-2.09c2.288 0 4.143-1.874 4.143-4.184S8.5 2.09 6.213 2.09c-2.287 0-4.142 1.874-4.142 4.184s1.856 4.183 4.143 4.183z"></path>
         </svg>
         Search
       </Link>
@@ -57,6 +57,7 @@ const phablet = '@media(max-width: 800px)'
 const styles = {
   container: {
     width: rhythm(8),
+    padding: '20px',
     [phablet]: {
       ...scale(0),
       width: 'auto',
@@ -98,6 +99,8 @@ const styles = {
   link1: {
     fontWeight: 'bold',
     ...scale(0),
+    marginTop: '6px',
+    marginBottom: '6px',
   },
 
   children: {
@@ -107,7 +110,7 @@ const styles = {
     padding: 0,
     paddingLeft: rhythm(.5),
     marginLeft: 0,
-    borderLeft: '1px solid #aaa',
+    borderLeft: '1px solid ' + dividerLine,
   },
 
   rootChildren: {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -154,7 +154,7 @@ const styles = {
     fontSize: '1.1em',
     lineHeight: '1.5em',
     textAlign: 'center',
-    textShadow: '1px 1px white',
+    textShadow: '0px 1px #f4f2f2',
     padding: '0.8em',
     marginBottom: 0,
     fontFamily: headerFontFamily(),
@@ -191,7 +191,7 @@ const styles = {
 
   featuresDivider: {
     height: 1,
-    backgroundColor: '#cecece',
+    backgroundColor: '#d6d4d4',
   },
   features: {
     // backgroundColor: '#d0d0d0',

--- a/src/templates/Guide.js
+++ b/src/templates/Guide.js
@@ -3,7 +3,7 @@ import Helmet from "react-helmet"
 
 import Section from '../components/Section'
 import GuideSidebar, {constructTree, fixPath} from '../components/GuideSidebar'
-import {accent, gray} from '../utils/colors'
+import {accent, gray, dividerLine} from '../utils/colors'
 import editIcon from '../../static/edit-icon.svg'
 
 import Link from "../components/Link"
@@ -125,11 +125,12 @@ const styles = {
     lineHeight: '25px',
   },
   title: {
-    borderBottom: '1px solid #aaa',
+    borderBottom: '1px solid ' + dividerLine,
     display: 'flex',
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'flex-end',
+    paddingBottom: '4px'
   },
   contentSection: {
     flexDirection: 'row',

--- a/src/templates/Search.js
+++ b/src/templates/Search.js
@@ -3,7 +3,7 @@ import Helmet from "react-helmet"
 
 import Section from '../components/Section'
 import GuideSidebar, {constructTree, fixPath} from '../components/GuideSidebar'
-import {accent, gray} from '../utils/colors'
+import {accent, gray, dividerLine} from '../utils/colors'
 import {rhythm} from '../utils/typography'
 
 import Link from "../components/Link"
@@ -158,7 +158,7 @@ const styles = {
     lineHeight: '25px',
   },
   title: {
-    borderBottom: '1px solid #aaa',
+    borderBottom: '1px solid ' + dividerLine,
     display: 'flex',
     flexDirection: 'row',
     justifyContent: 'space-between',

--- a/src/utils/colors.js
+++ b/src/utils/colors.js
@@ -1,2 +1,4 @@
-export const accent = '#db4d3f'
-export const gray = '#f6f4f4'
+export const accent = '#db4d3f';
+export const gray = '#f6f4f4';
+export const text = '#555';
+export const dividerLine = 'rgb(214, 212, 212)';

--- a/src/utils/typography.js
+++ b/src/utils/typography.js
@@ -3,6 +3,7 @@ import React from 'react'
 import Typography from 'typography'
 import CodePlugin from 'typography-plugin-code'
 import { MOBILE_MEDIA_QUERY } from 'typography-breakpoint-constants'
+import {text} from '../utils/colors'
 
 const options = {
   baseFontSize: '18px',
@@ -15,15 +16,21 @@ const options = {
     'sans-serif',
   ],
   bodyFontFamily: [
-    'Merriweather',
-    'Book Antiqua',
-    'Georgia',
-    'Century Schoolbook',
-    'serif'
+    '-apple-system',
+    'system-ui',
+    'BlinkMacSystemFont',
+    '"Segoe UI"',
+    'Roboto',
+    '"Helvetica Neue"',
+    'Arial',
+    'sans-serif'
   ],
   scaleRatio: 2.25,
   plugins: [new CodePlugin()],
   overrideStyles: ({ rhythm, scale }, options) => ({
+    body: {
+      color: text
+    },
     [MOBILE_MEDIA_QUERY]: {
       // Make baseFontSize on mobile 16px.
       html: {

--- a/static/edit-icon.svg
+++ b/static/edit-icon.svg
@@ -1,4 +1,4 @@
-<svg fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<svg fill="#555" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
     <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/>
     <path d="M0 0h24v24H0z" fill="none"/>
 </svg>

--- a/syntax-highlighting/xcode.css
+++ b/syntax-highlighting/xcode.css
@@ -9,7 +9,7 @@ XCode style (c) Angel Garcia <angelgarcia.mail@gmail.com>
   overflow-x: auto;
   padding: 0.5em;
   background: #fff;
-  color: black;
+  color: #555;
   -webkit-text-size-adjust: none;
 }
 


### PR DESCRIPTION
Just some cleanup. Adjusting spacing to make it less cramped. Less contrast as well to make it easier on the eyes. Using the system font for UI (as the Yarn website does).

Before:

<img width="644" alt="screen shot 2017-08-28 at 11 51 22 pm" src="https://user-images.githubusercontent.com/977348/29808257-2831f31e-8c4c-11e7-8009-291eb2c28d1f.png">

After:
<img width="643" alt="screen shot 2017-08-28 at 11 51 38 pm" src="https://user-images.githubusercontent.com/977348/29808262-2f6e682e-8c4c-11e7-8d82-911a11362050.png">

