### PR TITLE
Fix alignment/spacing of logo

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -19,7 +19,7 @@ export default ({inverted}) => (
     }
   }}>
     <Link to="/" style={{textDecoration: 'none', color: 'currentColor'}} >
-      <img style={{width: 50, maxWidth: 50, margin: 0, border: `2px solid ${gray}`, boxSizing: 'content-box'}} src={icon} width={50}/>
+      <img style={{display: 'block', width: 50, maxWidth: 50, margin: 0, border: `2px solid ${gray}`, boxSizing: 'content-box'}} src={icon} width={50}/>
     </Link>
     <HeaderNav />
   </div>


### PR DESCRIPTION
It used to look like

<img width="83" alt="screen shot 2017-09-01 at 4 53 41" src="https://user-images.githubusercontent.com/5207036/29975335-3ce502a0-8f36-11e7-9d34-316ece8ff357.png">

and now it looks like

<img width="99" alt="screen shot 2017-09-01 at 4 53 22" src="https://user-images.githubusercontent.com/5207036/29975346-44257392-8f36-11e7-820f-5cedb847db63.png">

