### PR TITLE
Move playground evaluation into a web worker, terminate on timeout

### DIFF
--- a/src/pages/try.js
+++ b/src/pages/try.js
@@ -309,7 +309,6 @@ export default class Try extends Component {
     return (
       <div css={styles.container}>
         <Helmet>
-          <script async src={__PATH_PREFIX__ + '/stdlibBundle.js'} />
           <script async src={__PATH_PREFIX__ + '/bs.js'} />
           <script async src={__PATH_PREFIX__ + '/refmt.js'} />
           <title>Try Reason</title>

--- a/static/evalWorker.js
+++ b/static/evalWorker.js
@@ -1,3 +1,5 @@
+importScripts('stdlibBundle.js');
+
 const _console = console;
 
 console = {

--- a/static/evalWorker.js
+++ b/static/evalWorker.js
@@ -1,0 +1,12 @@
+const _console = console;
+
+console = {
+  log: (...items) => postMessage({ type: 'log', contents: items }),
+  error: (...items) => postMessage({ type: 'error', contents: items }),
+  warn: (...items) => postMessage({ type: 'warn', contents: items })
+};
+
+onmessage = ({data}) => {
+  eval(data.code);
+  postMessage({ type: 'end', contents: data.timerId });
+};


### PR DESCRIPTION
Fixes #131 

This will need some more testing and tweaking of thresholds I think. The timeout is currently set to just 1 second, and I've also added a logging limit currently set to 100 items, but there's still some freezing on my end. Question is whether it's acceptable.