### PR TITLE
Add section on using existing JS libs to interop docs

### DIFF
--- a/src/pages/guide/javascript/interop.md
+++ b/src/pages/guide/javascript/interop.md
@@ -166,9 +166,9 @@ Wow! Notice how BuckleScript just inlined our `pi` variable for us? And the outp
 
 ## Using existing JavaScript libraries
 
-When someone writes bindings for a particular JavaScript library, if they're a good citizen, they'll usually collect them in a separate package and publish it to npm. Head over to the [Libraries](/guide/javascript/libraries) to find out how to find these.
+When folks write bindings for a particular JavaScript library, they'd usually publish it to npm. Head over to the [Libraries](/guide/javascript/libraries) to find out how to find these.
 
-If you want to use a library that does not have existing bindings, however, you'll want to first install the npm package as usual, e.g. using `npm install --save <package-name>`, then just go ahead and write your bindings. You'll probably find the [`bs.module`](https://bucklescript.github.io/bucklescript/Manual.html#_binding_to_a_value_from_a_module_code_bs_module_code) FFI attribtue particularly useful, it will make sure to emit the right `import`s (or `require`s, depending on the target format).
+To use a library that does not have existing bindings, however, you'll want to first install the npm package as usual, e.g. using `npm install --save <package-name>`, then just go ahead and write your bindings. You'll probably find the [`bs.module`](https://bucklescript.github.io/bucklescript/Manual.html#_binding_to_a_value_from_a_module_code_bs_module_code) FFI feature particularly useful; it emits the right `import`s or `require`s, depending on the JS compilation target's module format.
 
 As an example, here's the entire source code of the [`bs.glob`](https://github.com/reasonml-community/bs-glob) bindings (converted to Reason, the original is OCaml):
 

--- a/src/pages/guide/javascript/interop.md
+++ b/src/pages/guide/javascript/interop.md
@@ -172,7 +172,7 @@ If you want to use a library that does not have existing bindings, however, you'
 
 As an example, here's the entire source code of the [`bs.glob`](https://github.com/reasonml-community/bs-glob) bindings (converted to Reason, the original is OCaml):
 
-```ml
+```reason
 type error;
 
 external glob : string => (Js.nullable error => array string => unit) => unit = "" [@@bs.module];

--- a/src/pages/guide/javascript/interop.md
+++ b/src/pages/guide/javascript/interop.md
@@ -175,7 +175,7 @@ As an example, here's the entire source code of the [`bs.glob`](https://github.c
 ```ml
 type error;
 
-external glob : string => (Js.null error => array string => unit) => unit = "" [@@bs.module];
+external glob : string => (Js.nullable error => array string => unit) => unit = "" [@@bs.module];
 external sync : string => array string = "" [@@bs.val] [@@bs.module "glob"];
 ```
 

--- a/src/pages/guide/javascript/interop.md
+++ b/src/pages/guide/javascript/interop.md
@@ -163,3 +163,34 @@ ctx.fillRect(0.0, 0.0, 100.0, 100.0);
 ```
 
 Wow! Notice how BuckleScript just inlined our `pi` variable for us? And the output looks almost exactly like it was written by hand.
+
+## Using existing JavaScript libraries
+
+When someone writes bindings for a particular JavaScript library, if they're a good citizen, they'll usually collect them in a separate package and publish it to npm. Head over to the [Libraries](/guide/javascript/libraries) to find out how to find these.
+
+If you want to use a library that does not have existing bindings, however, you'll want to first install the npm package as usual, e.g. using `npm install --save <package-name>`, then just go ahead and write your bindings. You'll probably find the [`bs.module`](https://bucklescript.github.io/bucklescript/Manual.html#_binding_to_a_value_from_a_module_code_bs_module_code) FFI attribtue particularly useful, it will make sure to emit the right `import`s (or `require`s, depending on the target format).
+
+As an example, here's the entire source code of the [`bs.glob`](https://github.com/reasonml-community/bs-glob) bindings (converted to Reason, the original is OCaml):
+
+```ml
+type error;
+
+external glob : string => (Js.null error => array string => unit) => unit = "" [@@bs.module];
+external sync : string => array string = "" [@@bs.val] [@@bs.module "glob"];
+```
+
+And the releavnt parts of `package.json`:
+
+```js
+{
+  "name": "bs-glob",
+  "version": "0.1.0",
+  ...
+  "devDependencies": {
+    "bs-platform": "^1.9.0"
+  },
+  "dependencies": {
+    "glob": "^7.1.2"
+  }
+}
+```

--- a/src/pages/guide/javascript/interop.md
+++ b/src/pages/guide/javascript/interop.md
@@ -179,7 +179,7 @@ external glob : string => (Js.nullable error => array string => unit) => unit = 
 external sync : string => array string = "" [@@bs.val] [@@bs.module "glob"];
 ```
 
-And the releavnt parts of `package.json`:
+And the relevant parts of `package.json`:
 
 ```js
 {
@@ -187,7 +187,7 @@ And the releavnt parts of `package.json`:
   "version": "0.1.0",
   ...
   "devDependencies": {
-    "bs-platform": "^1.9.0"
+    "bs-platform": "^1.9.1"
   },
   "dependencies": {
     "glob": "^7.1.2"


### PR DESCRIPTION
Addresses feedback from SO: https://stackoverflow.com/questions/46012654/how-to-use-npm-packages-with-reasonml-reactreason