### PR TITLE
NPM install should handle sudo/root constraints

### DIFF
--- a/src/pages/guide/editor-tools/global-installation.md
+++ b/src/pages/guide/editor-tools/global-installation.md
@@ -9,8 +9,8 @@ order: 10
 
 | Platform  | Install command
 |-----------|-------------------------------------------------------------------------------------------------
-| **OSX**   | `npm install -g https://github.com/reasonml/reason-cli/archive/beta-v-1.13.6-bin-darwin.tar.gz`
-| **Linux** | `npm install -g https://github.com/reasonml/reason-cli/archive/beta-v-1.13.6-bin-linux.tar.gz`
+| **OSX**   | `npm install -g https://github.com/reasonml/reason-cli/archive/beta-v-1.13.7-bin-darwin.tar.gz`
+| **Linux** | `npm install -g --unsafe-perm https://github.com/reasonml/reason-cli/archive/beta-v-1.13.7-bin-linux.tar.gz`
 
 **`reason-cli` currently doesn't work on Windows**, but it's not a hard requirement for using Reason; you still have great CLI build system diagnosis messages through BuckleScript, whose npm global package [`bs-platform`](https://www.npmjs.com/package/bs-platform) does work on Windows.
 


### PR DESCRIPTION
When npm global installations are required to be run as sudo/root, the postinstall.sh file is denied execute permission by default by npm. To allow the script to execute we must set the --unsafe-perm config option.

This change also updates the cli tar.gz version to the most recent 1.13.7.