### PR TITLE
Add an example of using Js.Nullable.to_opt

### DIFF
--- a/src/pages/guide/examples.md
+++ b/src/pages/guide/examples.md
@@ -67,3 +67,18 @@ external store : store = "./store" [@@bs.module];
 Js.log store;
 Js.log (store##getDate ());
 ```
+
+### Checking for JS nullable types using the `option` type
+If you are writing a function that will be called by Javascript you may need to check if an argument's value is `null` or `undefined`. To do this we can simply use Bucklescript's [`Js.Nullable`](http://bucklescript.github.io/bucklescript/api/Js.html#TYPEnullable) type to lift this value into the `option` type from the standard library:
+
+```reason
+let greetByName = fun possiblyNullName => {
+  let optionName = Js.Nullable.to_opt possiblyNullName;
+  switch optionName {
+  | None => "Hello"
+  | Some name => "Hello " ^ name
+  }
+};
+```
+
+This check compiles to `possiblyNullName == null` in JS, so checks for the presence of `null` or `undefined`.

--- a/src/pages/guide/examples.md
+++ b/src/pages/guide/examples.md
@@ -69,13 +69,13 @@ Js.log (store##getDate ());
 ```
 
 ### Checking for JS nullable types using the `option` type
-If you are writing a function that will be called by Javascript you may need to check if an argument's value is `null` or `undefined`. To do this we can simply use Bucklescript's [`Js.Nullable`](http://bucklescript.github.io/bucklescript/api/Js.html#TYPEnullable) type to lift this value into the `option` type from the standard library:
+If you are writing a function that will be called by Javascript you may need to check if an argument's value is `null` or `undefined`. To do this we can simply use Bucklescript's [`Js.Nullable`](http://bucklescript.github.io/bucklescript/api/Js.html#TYPEnullable) type to convert this value into the `option` type from the standard library:
 
 ```reason
 let greetByName = fun possiblyNullName => {
   let optionName = Js.Nullable.to_opt possiblyNullName;
   switch optionName {
-  | None => "Hello"
+  | None => "Hi"
   | Some name => "Hello " ^ name
   }
 };

--- a/src/pages/guide/examples.md
+++ b/src/pages/guide/examples.md
@@ -69,10 +69,10 @@ Js.log (store##getDate ());
 ```
 
 ### Checking for JS nullable types using the `option` type
-If you are writing a function that will be called by Javascript you may need to check if an argument's value is `null` or `undefined`. To do this we can simply use Bucklescript's [`Js.Nullable`](http://bucklescript.github.io/bucklescript/api/Js.html#TYPEnullable) type to convert this value into the `option` type from the standard library:
+For a function whose argument is passed a JavaScript value that's potentially `null` or `undefined`, it's idiomatic to convert it to a Reason `option`. The conversion is done through the helper functions in Bucklescript's [`Js.Nullable`](http://bucklescript.github.io/bucklescript/api/Js.html#TYPEnullable) module. In this case, `to_opt`:
 
 ```reason
-let greetByName = fun possiblyNullName => {
+let greetByName possiblyNullName => {
   let optionName = Js.Nullable.to_opt possiblyNullName;
   switch optionName {
   | None => "Hi"


### PR DESCRIPTION
It took me quite a while to find a nice way of handling possibly null JS values. 

Highlighting the use of Js.Nullable.to_opt might save people some time.