### PR TITLE
Remove explicit watch mode command

### DIFF
--- a/src/pages/guide/javascript/quickstart.md
+++ b/src/pages/guide/javascript/quickstart.md
@@ -15,11 +15,7 @@ cd my-first-app
 npm run start
 ```
 
-You can also build in watch mode:
-
-```sh
-npm run watch
-```
+It runs in watch mode, so any changes to files will be picked up and compiled.
 
 That's all! This compiles Reason to Javascript in the `lib/js/` folder.
 


### PR DESCRIPTION
The explicit `npm run watch` command was removed in this commit: https://github.com/BuckleScript/bucklescript/commit/c8778eddc57467998715f91ea00edaee1ad141ec#diff-7b08ae4b16cddfb4e8606ad3e909ef23
Instead the `npm run start` command runs in watch mode