### PR TITLE
Fix the example shown on the front page

### DIFF
--- a/src/pages/index-example.md
+++ b/src/pages/index-example.md
@@ -1,7 +1,7 @@
 ```reason
 type schoolPerson = Teacher | Director | Student string;
 
-let greeting =
+let greeting stranger =>
   switch stranger {
   | Teacher => "Hey professor!"
   | Director => "Hello director."


### PR DESCRIPTION
The example on the [front page](https://reasonml.github.io/) always bugged me. It turns out it contains an error (or is incomplete): `Unbound value stranger`.
I suppose it was meant to be a function definition.