### PR TITLE
Force retrieve method to return string for `code`

### DIFF
--- a/src/pages/try.js
+++ b/src/pages/try.js
@@ -232,7 +232,7 @@ const retrieve = () => {
     fromQueryParam('reason') ||
     fromQueryParam('ocaml') ||
     fromLocalStorage() ||
-    { language: 'reason', code: decompress(examples[0].code) }
+    { language: 'reason', code: decompress(examples[0].code) || '' }
   );
 };
 


### PR DESCRIPTION
Earlier today I ran into an issue where when using the `/try` feature the REPLs kind of locked up on me with their `//loading` syntax stuck. I had to refresh to make it work.

I can reproduce by going to https://reasonml.github.io/try/ on an incognito window in chrome, it throws the following error:
```js
refmt.js:7 Uncaught TypeError: Cannot read property 'length' of null
    at Uy (refmt.js:7)
    at Zh (refmt.js:16)
    at refmt.js:1944
    at t.<anonymous> (page-component---src-pages-try-js-26d9201f0ec224a05d1a.js:7)
    at d._processPendingState (ReactCompositeComponent.js:674)
    at d.updateComponent (ReactCompositeComponent.js:617)
    at d.performUpdateIfNecessary (ReactCompositeComponent.js:560)
    at Object.performUpdateIfNecessary (ReactReconciler.js:156)
    at a (ReactUpdates.js:150)
    at o.perform (Transaction.js:143)
```
Here is a screenshot:
<img width="1440" alt="screen shot 2017-10-08 at 11 30 28 am" src="https://user-images.githubusercontent.com/3782604/31318721-267f2d94-ac1c-11e7-85cf-7de99979a5cb.png">

I was also able to reproduce it locally.

It looks like when you come to the site for the first time the `code` for the `reason` language is initially coming in as `null` instead of `''`.

I cannot for the life of me figure out why though 🤔. The line I updated fixed the issue, but I don't know why `decompress` is returning `examples[0].code` as `null`.

My change fixes it but I am open to doing it a different way if someone else has any kind of idea why `decompress` would be doing that.

Here is a gif of me looking at the values with a breakpoint:
![example](https://user-images.githubusercontent.com/3782604/31318762-abe73a8a-ac1c-11e7-929c-74d19173ba52.gif)

**Apologies if this is a known issue or has been reported / PR'd already. I couldn't find a duplicate on GitHub**

THANKS!


