### PR TITLE
Fix Exception.md example type error

### DIFF
--- a/src/pages/guide/language/exception.md
+++ b/src/pages/guide/language/exception.md
@@ -17,7 +17,7 @@ let getItem theList => {
 };
 
 let result = try (getItem [1, 2, 3]) {
-| Not_found => print_endline "Item not found!"
+| Not_found => failwith "Item not found!"
 };
 ```
 

--- a/src/pages/guide/language/exception.md
+++ b/src/pages/guide/language/exception.md
@@ -17,9 +17,11 @@ let getItem theList => {
 };
 
 let result = try (getItem [1, 2, 3]) {
-| Not_found => failwith "Item not found!"
+| Not_found => 0 /* Default value if getItem throws */
 };
 ```
+
+Note that the above is just for demonstration purposes; in reality, you'd return an `option int` directly from `getItem` and avoid the `try` altogether.
 
 You can directly match on exceptions _while_ getting another return value from a function:
 


### PR DESCRIPTION
The current example does not type check ([try](https://reasonml.github.io/try/?reason=DYUwLgBA5uCSYgLYQBRgBYgDIEsDOkAXBMPpDgHZgCUEAvAHwQDeAUBBDgGaq4EB0oClAwQM2MhCYAGWmw4c+YfugAmYzEvYQAvhBDA8IFto4AnAIb5jAOQD2YAPpc7AVwqrtO1joDcrVlBIMxA8V2BIOjEzAE9UGDB4JAgAbQBGABoIACYsgGYAXTlWAB8IeycXd3VGCAAHM0onEA9SCmMAIiTkCgcIKo8AQg6fXyA)). `result` expects `int` (the item) but is given `unit` from `print_endline`.

The proposed change (with `failwith`) type checks ([try](https://reasonml.github.io/try/?reason=DYUwLgBA5uCSYgLYQBRgBYgDIEsDOkAXBMPpDgHZgCUEAvAHwQDeAUBBDgGaq4EB0oClAwQM2MhCYAGWmw4c+YfugAmYzEvYQAvhBDA8IFto4AnAIb5jAOQD2YAPpc7AVwqrtO1joDcrVlBIMxA8V2BIOjEzAE9UGDB4JAgAbQBGABoIACYsgGYAXTlWAB8IeycXd3VGCC4rYAB3HFEAIiTkCgc6tw8AQlafXyA)), but not sure if rethrowing is acceptable as an example.

We might want to show how "catching" exceptions can return a value, I think it's a great feature to show off ([link to tweet](https://twitter.com/aureliengeorget/status/923150639047348224)). But then again it might encourage people to use exceptions, so I'm not sure on this one too. Would love to update this PR if that's what preferred.