### PR TITLE
Update opam installation versions

### DIFF
--- a/src/pages/guide/editor-tools/global-installation.md
+++ b/src/pages/guide/editor-tools/global-installation.md
@@ -22,8 +22,8 @@ order: 10
 ```
 opam update
 opam switch 4.02.3 # mandatory!
-opam install reason.1.13.7
-opam install merlin.2.5.4
+opam install reason
+opam install merlin
 ```
 
 ### Troubleshooting


### PR DESCRIPTION
The opam installation versions are locked to older versions of merlin and reason. Is there a reason these are locked at these versions or have they just been missed in doc updates?

Removing the version constraints will install the latest, which should be the desired case for most users and will have the added benefit of not needing to update this file for version changes