### PR TITLE
Update syntax-cheatsheet jsx example

### DIFF
--- a/src/pages/guide/javascript/syntax-cheatsheet.md
+++ b/src/pages/guide/javascript/syntax-cheatsheet.md
@@ -151,9 +151,9 @@ JavaScript                |   Reason
 
 JavaScript                |   Reason
 --------------------------|--------------------------------
-`<Foo bar=1 baz="hi" onClick={bla} />`  |  Same
-`<Foo bar=bar />`                       |  `<Foo bar />` \*
-`<input checked />`                     |  `<input checked=true />`
+`<Foo bar={1} baz="hi" onClick={bla} />`  |  Same
+`<Foo bar={bar} />`                       |  `<Foo bar />` \*
+`<input checked />`                       |  `<input checked=true />`
 
 \* Argument punning!
 


### PR DESCRIPTION
The JSX examples in the syntax cheatsheet had invalid syntax for javascript. This pull request fixes that.