### PR TITLE
Float exponentiation operator in primitives table

### DIFF
--- a/src/pages/guide/language/overview.md
+++ b/src/pages/guide/language/overview.md
@@ -13,6 +13,7 @@ Integer Addition                      |  `23 + 1`
 Float Addition                        |  `23.0 +. 1.0`
 Integer Division/Multiplication       |  `2 / 23 * 1`
 Float Division/Multiplication         |  `2.0 /. 23.0 *. 1.0`
+Float Exponentiation                  |  `2.0 ** 2.0`
 String Concatenation                  |  `"Hello " ++ "World"`
 Comparison                            |  `>`, `<`, `>=`, `=<`
 Boolean operations                    |  `!`, `&&`, `||`


### PR DESCRIPTION
The float exponentiation operator was missing in the overview documentation.