### PR TITLE
Add running with Node instructions to quickstart.md

### DIFF
--- a/src/pages/guide/javascript/quickstart.md
+++ b/src/pages/guide/javascript/quickstart.md
@@ -15,9 +15,7 @@ cd my-first-app
 npm run start
 ```
 
-It runs in watch mode, so any changes to files will be picked up and compiled.
-
-That's all! This compiles Reason to Javascript in the `lib/js/` folder.
+It runs in watch mode, so any changes to files will be picked up and compiled. That's all!
 
 - Read more about how we compile to JavaScript through our partner project, [BuckleScript](http://bucklescript.github.io/bucklescript/Manual.html).
 

--- a/src/pages/guide/javascript/quickstart.md
+++ b/src/pages/guide/javascript/quickstart.md
@@ -15,7 +15,16 @@ cd my-first-app
 npm run start
 ```
 
-It runs in watch mode, so any changes to files will be picked up and compiled. That's all!
+It runs in watch mode, so any changes to files will be picked up and compiled.
+
+Next try running your compiled code with `node`:
+
+```sh
+> node src/demo.bs.js
+Hello, BuckleScript and Reason!
+```
+
+That's all!
 
 - Read more about how we compile to JavaScript through our partner project, [BuckleScript](http://bucklescript.github.io/bucklescript/Manual.html).
 

--- a/src/pages/guide/language/external.md
+++ b/src/pages/guide/language/external.md
@@ -18,6 +18,8 @@ external myCFunction : int => string = "theCFunction";
 
 (The above is a [BuckleScript](https://bucklescript.github.io/bucklescript/Manual.html)-specific external that binds to a JavaScript function of the same name.)
 
+**Note**: `external`s can only be at the top level, or inside a module definition. You can't declare them in e.g. a function body.
+
 ### Usage
 
 You'd use an external value/function as if it was a normal let binding.

--- a/src/pages/guide/language/object.md
+++ b/src/pages/guide/language/object.md
@@ -50,7 +50,7 @@ let obj: tesla = {
 
 This object is of object type tesla and has a public method `drive`. It also contains a private method `enableEnvy` that is only accessible from within the object.
 
-As you can see, a Reason object can also access `this`. Just like a JavaScript object's `this`, our `this` has very erratic behavior depending on the context. Just kidding. Our `this` always points to the object itself correctly. Gotta learn from history.
+As you can see, a Reason object can also access `this`. JavaScript object's `this` behavior can be quirky; Reason `this` always points to the object itself correctly.
 
 The following example shows an open object type which uses a type as parameter. The object type parameter is required to implement all the methods of the open object type.
 

--- a/src/pages/guide/ocaml.md
+++ b/src/pages/guide/ocaml.md
@@ -548,12 +548,10 @@ module type MySig = {
   type t = int;
   let x: int;
 };
-
 module MyModule: MySig = {
   type t = int;
   let x = 10;
 };
-
 module MyModule = {
   module NestedModule = {
     let msg = "hello";


### PR DESCRIPTION
Hi!

I am a total noobie with ReasonML with around 15 minutes of experience under my belt. When going through the quickstart and installing the dependencies everything went smoothly until I wanted to actually try running the code I had written. Took me embarrassingly long to figure out that I can just run the `bs.js` files under `node` to test the output out to see if everything just worked.

I added an extra step of running the demo.bs.js file under `src/` after build with `node` so the user can see at least _some_ output after doing all the work of installing the dependencies and all.

Do tell if one should be running something else altogether, like I said I really have no idea what I am doing yet 👍 
 