### PR TITLE
Fix typo on Variant page

### DIFF
--- a/src/pages/guide/language/variant.md
+++ b/src/pages/guide/language/variant.md
@@ -129,7 +129,7 @@ type account2 =
 ```
 #### Variants Must Have constructors
 
-If you come from an untyped language, you might be tempted to try `type foo = int | string`. This isn't possible in Reason; you'd have to give each branch a constructor: `type foo = Int(int) | String(int)`. Though usually, needing this might be an anti-pattern. The Design Decisions section below explains more.
+If you come from an untyped language, you might be tempted to try `type foo = int | string`. This isn't possible in Reason; you'd have to give each branch a constructor: `type foo = Int(int) | String(string)`. Though usually, needing this might be an anti-pattern. The Design Decisions section below explains more.
 
 #### Interop with JavaScript
 


### PR DESCRIPTION
Fixed a typo where `type foo = Int(int) | String(int)` should have been `type foo = Int(int) | String(string)` (unless I somehow misinterpreted what's going on).