### PR TITLE
Fix the Exception section's try example

### DIFF
--- a/docs/syntax-cheatsheet.md
+++ b/docs/syntax-cheatsheet.md
@@ -177,7 +177,7 @@ JavaScript                |   Reason
     <td>
       <pre>
         try { ... }
-        catch (Err) { ... }
+        catch (e) { ... }
         finally { ... }
       </pre>
     </td>
@@ -186,7 +186,7 @@ JavaScript                |   Reason
         try {
           ...
         } {
-          | Err => 
+          | e => 
         } *
       </pre>
     </td>

--- a/docs/syntax-cheatsheet.md
+++ b/docs/syntax-cheatsheet.md
@@ -159,11 +159,40 @@ JavaScript                |   Reason
 
 ## Exception
 
-JavaScript                |   Reason
---------------------------|--------------------------------
-`throw new SomeError(...)`  |  `raise(SomeError(...))`
-`try (a) {...} catch (Err) {...} finally {...}`   |  `try a { | Err => ...}` \*
-
+<table>
+  <thead><tr> <th scope="col"><p >JavaScript</p></th> <th scope="col"><p>Reason</p></th></tr></thead>
+  <tr>
+    <td>
+      <pre>
+        throw new SomeError(...)
+      </pre>
+    </td>
+    <td>
+      <pre>
+        raise(SomeError(...))
+      </pre>
+    </td>
+  </tr>
+  <tr>  
+    <td>
+      <pre>
+        try { ... }
+        catch (Err) { ... }
+        finally { ... }
+      </pre>
+    </td>
+    <td>
+      <pre>
+        try {
+          ...
+        } {
+          | Err => 
+        } *
+      </pre>
+    </td>
+  </tr>
+</table>
+   
 \* No finally.
 
 ## Blocks


### PR DESCRIPTION
Currently it renders incorrectly when it's converted from Markdown to HTML; cutting off the matcher. Using the inline code syntax in a Markdown table does not yield the correct syntax, thus a `<table>` has to be used.