### PR TITLE
Fix broken formatting in cheatsheet

### DIFF
--- a/docs/syntax-cheatsheet.md
+++ b/docs/syntax-cheatsheet.md
@@ -7,90 +7,90 @@ We've worked very hard to make Reason look like JS while preserving OCaml's grea
 
 ## Let Binding
 
-JavaScript                |   Reason
---------------------------|--------------------------------
-`const x = 5;`              |  `let x = 5;`
-`var x = y;`                |  No equivalent (thankfully)
-`let x = 5; x = x + 1;`     |  `let x = ref(5); x := x^ + 1;`
+| JavaScript              | Reason                         |
+| ----------------------- | ------------------------------ |
+| `const x = 5;`          | `let x = 5;`                   |
+| `var x = y;`            | No equivalent (thankfully)     |
+| `let x = 5; x = x + 1;` | `let x = ref(5); x := x^ + 1;` |
 
 ## String & Char
 
-JavaScript                |   Reason
---------------------------|--------------------------------
-`"Hello world!"`            |  Same
-`'Hello world!'`            |  Strings must use `"`
-Characters are strings      |  `'a'`
-`"hello " + "world"`        |  `"hello " ++ "world"`
+| JavaScript             | Reason                |
+| ---------------------- | --------------------- |
+| `"Hello world!"`       | Same                  |
+| `'Hello world!'`       | Strings must use `"`  |
+| Characters are strings | `'a'`                 |
+| `"hello " + "world"`   | `"hello " ++ "world"` |
 
 ## Boolean
 
-JavaScript                |   Reason
---------------------------|--------------------------------
-`true`, `false`                      |  `true`, `false` \*
-`!true`                              |  Same
-`||`, `&&`, `<=`, `>=`, `<`, `>`     |  Same
-`a === b`, `a !== b`                 |  Same
-No deep equality (recursive compare) |  `a == b`, `a != b`
-`a == b`                             |  No equality with implicit casting (thankfully)
+| JavaScript                                            | Reason                                         |
+| ----------------------------------------------------- | ---------------------------------------------- |
+| `true`, `false`                                       | `true`, `false` \*                             |
+| `!true`                                               | Same                                           |
+| <code>&#124;&#124;</code>, `&&`, `<=`, `>=`, `<`, `>` | Same                                           |
+| `a === b`, `a !== b`                                  | Same                                           |
+| No deep equality (recursive compare)                  | `a == b`, `a != b`                             |
+| `a == b`                                              | No equality with implicit casting (thankfully) |
 
 \* This is the Reason spiritual equivalent; it doesn't mean it compiles to JS' `true`/`false`! To compile to the latter, use `Js.true_`/`Js.false_`. See [here](/guide/language/boolean#usage).
 
 ## Number
 
-JavaScript                |   Reason
---------------------------|--------------------------------
-`3`                         |  Same \*
-`3.1415`                    |  Same
-`3 + 4`                     |  Same
-`3.0 + 4.5`                 |  `3.0 +. 4.5`
-`5 % 3`                     |  `5 mod 3`
+| JavaScript  | Reason       |
+| ----------- | ------------ |
+| `3`         | Same \*      |
+| `3.1415`    | Same         |
+| `3 + 4`     | Same         |
+| `3.0 + 4.5` | `3.0 +. 4.5` |
+| `5 % 3`     | `5 mod 3`    |
 
 \* JS has no distinction between integer and float.
 
 ## Object/Record
 
-JavaScript                |   Reason
---------------------------|--------------------------------
-no static types           |  `type point = {x: int, mutable y: int}`
-`{x: 30, y: 20}`          |  Same \*
-`point.x`                 |  Same
-`point.y = 30;`           |  Same
-`{...point, x: 30}`       |  Same
+| JavaScript          | Reason                                  |
+| ------------------- | --------------------------------------- |
+| no static types     | `type point = {x: int, mutable y: int}` |
+| `{x: 30, y: 20}`    | Same \*                                 |
+| `point.x`           | Same                                    |
+| `point.y = 30;`     | Same                                    |
+| `{...point, x: 30}` | Same                                    |
 
 \* This is the Reason spiritual equivalent; it doesn't mean it compiles to JS' object! To compile to the latter, see [here](/guide/language/object#tip--tricks).
 
 ## Array
 
-JavaScript                |   Reason
---------------------------|--------------------------------
-`[1, 2, 3]`               |  `[|1, 2, 3|]`
-`myArray[1] = 10`         |  Same
-`[1, "Bob", true]` \*     |  `(1, "Bob", true)`
-No immutable list         |  `[1, 2, 3]`
+| JavaScript            | Reason                             |
+| --------------------- | ---------------------------------- |
+| `[1, 2, 3]`           | <code>[&#124;1, 2, 3&#124;]</code> |
+| `myArray[1] = 10`     | Same                               |
+| `[1, "Bob", true]` \* | `(1, "Bob", true)`                 |
+| No immutable list     | `[1, 2, 3]`                        |
 
 \* We can simulate tuples in JavaScript with arrays, because JavaScript arrays can contain multiple types of elements.
 
 ## Null
 
-JavaScript                |   Reason
---------------------------|--------------------------------
-`null`, `undefined`       |  `None` \*
+| JavaScript          | Reason    |
+| ------------------- | --------- |
+| `null`, `undefined` | `None` \* |
 
 \* Again, only a spiritual equivalent; Reason doesn't have nulls, nor null bugs! But it does have [an option type](/guide/examples#using-the-option-type) for when you actually need nullability.
 
 ## Function
 
-JavaScript                            |   Reason
---------------------------------------|--------------------------------
-`arg => retVal`                       |  `(arg) => retVal`
-`function named(arg) {...}`           |  `let named = (arg) => ...`
-`const f = function(arg) {...}`       |  `let f = (arg) => ...`
-`add(4, add(5, 6))`                   |  Same
+| JavaScript                      | Reason                     |
+| ------------------------------- | -------------------------- |
+| `arg => retVal`                 | `(arg) => retVal`          |
+| `function named(arg) {...}`     | `let named = (arg) => ...` |
+| `const f = function(arg) {...}` | `let f = (arg) => ...`     |
+| `add(4, add(5, 6))`             | Same                       |
 
 ### Blocks
 
 <table>
-  <thead><tr> <th scope="col"><p >JavaScript</p></th> <th scope="col"><p>Reason</p></th></tr></thead>
+  <thead><tr> <th scope="col"><p>JavaScript</p></th> <th scope="col"><p>Reason</p></th></tr></thead>
   <tr>
     <td>
       <pre>
@@ -113,56 +113,56 @@ let myFun = (x, y) => {
 
 ### Currying
 
-JavaScript                |   Reason
---------------------------|--------------------------------
-`let add = a => b => a + b`       |  `let add = (a, b) => a + b`
+| JavaScript                  | Reason                      |
+| --------------------------- | --------------------------- |
+| `let add = a => b => a + b` | `let add = (a, b) => a + b` |
 
 Both JavaScript and Reason support currying, but Reason currying is **built-in and optimized to avoid intermediate function allocation & calls**, whenever possible.
 
 ## If-else
 
-JavaScript                |   Reason
---------------------------|--------------------------------
-`if (a) {b} else {c}`     |  Same \*
-`a ? b : c`               |  Same
-`switch`                  |  `switch` but [super-powered!](/guide/language/pattern-matching)
+| JavaScript            | Reason                                                          |
+| --------------------- | --------------------------------------------------------------- |
+| `if (a) {b} else {c}` | Same \*                                                         |
+| `a ? b : c`           | Same                                                            |
+| `switch`              | `switch` but [super-powered!](/guide/language/pattern-matching) |
 
 \* Reason conditionals are always expressions!
 
 ## Destructuring
 
-JavaScript                |   Reason
---------------------------|--------------------------------
-`const {a, b} = data`             |  `let {a, b} = data`
-`const [a, b] = data`             |  `let [|a, b|] = data` \*
-`const {a: aa, b: bb} = data`     |  `let {a: aa, b: bb} = data`
+| JavaScript                    | Reason                                        |
+| ----------------------------- | --------------------------------------------- |
+| `const {a, b} = data`         | `let {a, b} = data`                           |
+| `const [a, b] = data`         | <code>let [&#124;a, b&#124;] = data</code> \* |
+| `const {a: aa, b: bb} = data` | `let {a: aa, b: bb} = data`                   |
 
 \* Gives good compiler warning that `data` might not be of length 2. Switch to pattern-matching instead.
 
 ## Loop
 
-JavaScript                |   Reason
---------------------------|--------------------------------
-`for (let i = 0; i <= 10; i++) {...}`             |  `for (i in 0 to 10) {...}`
-`for (let i = 10; i >= 0; i--) {...}`             |  `for (i in 10 downto 0) {...}`
-`while (true) {...}`                              |  Same
+| JavaScript                            | Reason                         |
+| ------------------------------------- | ------------------------------ |
+| `for (let i = 0; i <= 10; i++) {...}` | `for (i in 0 to 10) {...}`     |
+| `for (let i = 10; i >= 0; i--) {...}` | `for (i in 10 downto 0) {...}` |
+| `while (true) {...}`                  | Same                           |
 
 ## JSX
 
-JavaScript                |   Reason
---------------------------|--------------------------------
-`<Foo bar=1 baz="hi" onClick={bla} />`  |  Same
-`<Foo bar=bar />`                       |  `<Foo bar />` \*
-`<input checked />`                     |  `<input checked=true />`
+| JavaScript                             | Reason                   |
+| -------------------------------------- | ------------------------ |
+| `<Foo bar=1 baz="hi" onClick={bla} />` | Same                     |
+| `<Foo bar=bar />`                      | `<Foo bar />` \*         |
+| `<input checked />`                    | `<input checked=true />` |
 
 \* Argument punning!
 
 ## Exception
 
-JavaScript                |   Reason
---------------------------|--------------------------------
-`throw new SomeError(...)`  |  `raise(SomeError(...))`
-`try (a) {...} catch (Err) {...} finally {...}`   |  `try a { | Err => ...}` \*
+| JavaScript                                      | Reason                                     |
+| ----------------------------------------------- | ------------------------------------------ |
+| `throw new SomeError(...)`                      | `raise(SomeError(...))`                    |
+| `try (a) {...} catch (Err) {...} finally {...}` | <code>try a { &#124; Err => ...}</code> \* |
 
 \* No finally.
 
@@ -194,7 +194,7 @@ let res = {
 
 ## Comments
 
-JavaScript                |   Reason
---------------------------|--------------------------------
-`/* Comment */`  |  Same
-`// line comment`  |  Coming soon
+| JavaScript        | Reason      |
+| ----------------- | ----------- |
+| `/* Comment */`   | Same        |
+| `// Line comment` | Coming soon |


### PR DESCRIPTION
The `|` characters in the [Syntax Cheatsheet's example code](https://reasonml.github.io/docs/en/syntax-cheatsheet.html#boolean) conflict with Markdown's table syntax which results in broken formatting. This PR converts all usage of `|` to `&#124;` and use `<code>` instead of backticks for those cells.

Built the website locally and verified all sections. You can also verify that it renders ok on my [fork](https://github.com/yangshun/reasonml.github.io/blob/cheatsheet/docs/syntax-cheatsheet.md).

**Broken**

<img width="797" alt="screen shot 2018-01-05 at 1 33 48 am" src="https://user-images.githubusercontent.com/1315101/34603386-9b64fba2-f1b8-11e7-80e7-0519a97f991e.png">

**Fixed**

<img width="597" alt="screen shot 2018-01-05 at 1 35 48 am" src="https://user-images.githubusercontent.com/1315101/34603436-c9d7f778-f1b8-11e7-9fe4-f15517ceb30b.png">

Fixes #288 
  