### PR TITLE
Improvements on links and code rendering

### DIFF
--- a/docs/articles-and-videos.md
+++ b/docs/articles-and-videos.md
@@ -23,7 +23,6 @@ Reason is just OCaml under the hood; We don't yet cover every concept on this do
 - [Interactive ReasonReact Tutorial](https://jaredforsyth.com/2017/07/05/a-reason-react-tutorial/): features runnable code and type hint on hover!
 - [A First Reason React app for Javascript developers](https://jamesfriend.com.au/a-first-reason-react-app-for-js-developers)
 - [Routing in Reason React](https://jamesfriend.com.au/routing-in-reason-react)
-- [Binding a React HOC to ReasonML Children as Function](https://medium.com/@_gabrielrubens/binding-a-react-hoc-to-reasonml-children-as-function-d2688e4edaae)
 
 ## Videos
 

--- a/docs/articles-and-videos.md
+++ b/docs/articles-and-videos.md
@@ -23,6 +23,7 @@ Reason is just OCaml under the hood; We don't yet cover every concept on this do
 - [Interactive ReasonReact Tutorial](https://jaredforsyth.com/2017/07/05/a-reason-react-tutorial/): features runnable code and type hint on hover!
 - [A First Reason React app for Javascript developers](https://jamesfriend.com.au/a-first-reason-react-app-for-js-developers)
 - [Routing in Reason React](https://jamesfriend.com.au/routing-in-reason-react)
+- [Binding a React HOC to ReasonML Children as Function](https://medium.com/@_gabrielrubens/binding-a-react-hoc-to-reasonml-children-as-function-d2688e4edaae)
 
 ## Videos
 

--- a/docs/syntax-cheatsheet.md
+++ b/docs/syntax-cheatsheet.md
@@ -76,7 +76,7 @@ JavaScript                |   Reason
 --------------------------|--------------------------------
 `null`, `undefined`       |  `None` \*
 
-\* Again, only a spiritual equivalent; Reason doesn't have nulls, nor null bugs! But it does have [an option type](/guide/examples#using-the-option-type) for when you actually need nullability.
+\* Again, only a spiritual equivalent; Reason doesn't have nulls, nor null bugs! But it does have [an option type](/docs/en/newcomer-examples.html#using-the-option-type) for when you actually need nullability.
 
 ## Function
 

--- a/docs/syntax-cheatsheet.md
+++ b/docs/syntax-cheatsheet.md
@@ -28,7 +28,7 @@ JavaScript                |   Reason
 --------------------------|--------------------------------
 `true`, `false`                      |  `true`, `false` \*
 `!true`                              |  Same
-`||`, `&&`, `<=`, `>=`, `<`, `>`     |  Same
+<code>&#124;&#124;</code>, `&&`, `<=`, `>=`, `<`, `>`     |  Same
 `a === b`, `a !== b`                 |  Same
 No deep equality (recursive compare) |  `a == b`, `a != b`
 `a == b`                             |  No equality with implicit casting (thankfully)
@@ -63,7 +63,7 @@ no static types           |  `type point = {x: int, mutable y: int}`
 
 JavaScript                |   Reason
 --------------------------|--------------------------------
-`[1, 2, 3]`               |  `[|1, 2, 3|]`
+`[1, 2, 3]`               |  <code>[&#124;1, 2, 3&#124;]</code>
 `myArray[1] = 10`         |  Same
 `[1, "Bob", true]` \*     |  `(1, "Bob", true)`
 No immutable list         |  `[1, 2, 3]`
@@ -136,7 +136,7 @@ JavaScript                |   Reason
 JavaScript                |   Reason
 --------------------------|--------------------------------
 `const {a, b} = data`             |  `let {a, b} = data`
-`const [a, b] = data`             |  `let [|a, b|] = data` \*
+`const [a, b] = data`             |  <code>let [&#124;a, b&#124;] = data</code> \*
 `const {a: aa, b: bb} = data`     |  `let {a: aa, b: bb} = data`
 
 \* Gives good compiler warning that `data` might not be of length 2. Switch to pattern-matching instead.
@@ -164,7 +164,7 @@ JavaScript                |   Reason
 JavaScript                |   Reason
 --------------------------|--------------------------------
 `throw new SomeError(...)`  |  `raise(SomeError(...))`
-`try (a) {...} catch (Err) {...} finally {...}`   |  `try a { | Err => ...}` \*
+`try (a) {...} catch (Err) {...} finally {...}`   |  <code>try a { &#124; Err => ...}</code> \*
 
 \* No finally.
 

--- a/docs/syntax-cheatsheet.md
+++ b/docs/syntax-cheatsheet.md
@@ -93,20 +93,22 @@ JavaScript                            |   Reason
   <thead><tr> <th scope="col"><p >JavaScript</p></th> <th scope="col"><p>Reason</p></th></tr></thead>
   <tr>
     <td>
-      <pre>
+      <code>
+        <pre>
 const myFun = (x, y) => {
   const doubleX = x + x;
   const doubleY = y + y;
   return doubleX + doubleY
-};</pre>
+};</pre></code>
     </td>
     <td>
-      <pre>
+      <code>
+        <pre>
 let myFun = (x, y) => {
   let doubleX = x + x;
   let doubleY = y + y;
   doubleX + doubleY
-};</pre>
+};</pre></code>
     </td>
   </tr>
 </table>
@@ -174,20 +176,22 @@ In Reason, "sequence expressions" are created with `{}` and evaluate to their la
   <thead><tr> <th scope="col"><p >JavaScript</p></th> <th scope="col"><p>Reason</p></th></tr></thead>
   <tr>
     <td>
-      <pre>
+      <code>
+        <pre>
 let res = (function() {
   const x = 23;
   const y = 34;
   return x + y;
-})();</pre>
+})();</pre></code>
     </td>
     <td>
-      <pre>
+      <code>
+        <pre>
 let res = {
   let x = 23;
   let y = 34;
   x + y
-};</pre>
+};</pre></code>
     </td>
   </tr>
 </table>


### PR DESCRIPTION
### This pull-request does:

- Fix broken link to `option` type on _Syntax Cheatsheet_
- Bypass Markdown parsing issue for `|`

| Before | Then |
|----|----|
| ![2018-01-05-142608_791x425_scrot](https://user-images.githubusercontent.com/7553006/34618092-cc72339c-f224-11e7-8e97-1cb512b818f8.png) | ![2018-01-05-142622_652x373_scrot](https://user-images.githubusercontent.com/7553006/34618097-d26bf5a8-f224-11e7-8a23-4ac29f98b255.png) |