### PR TITLE
Add keys to users on homepage

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -123,7 +123,7 @@ class Index extends React.Component {
     const showcase = siteConfig.users
       .map(user => {
         return (
-          <a href={user.infoLink}>
+          <a href={user.infoLink} key={user.infoLink}>
             <img src={`${siteConfig.baseUrl}${user.image}`} title={user.caption} />
           </a>
         );


### PR DESCRIPTION
Fix React key warning issue that appears in console

```
Starting Docusaurus server on port 3000...
Open http://localhost:3000/
Warning: Each child in an array or iterator should have a unique "key" prop. Check the render method of `Index`. See https://fb.me/react-warning-keys for more information.
    in a (created by Index)
    in Index
    in div (created by Site)
    in body (created by Site)
    in html (created by Site)
    in Site
```