### PR TITLE
Added horizontal scroll for code example for screens smaller than 480px

### DIFF
--- a/website/static/css/reason.css
+++ b/website/static/css/reason.css
@@ -194,6 +194,11 @@ pre code {
   .projectTitle {
     font-size: 30px;
   }
+  
+  .homeCodeSnippet {
+    overflow-x: auto;
+    width: 100%;
+  }
 
   .homeCodeSnippet .hljs {
     font-size: 13px;


### PR DESCRIPTION
Problem overview: https://i.imgur.com/JbL4c2W.png

I was viewing the website on my galaxy J5 and this problem occured. The code example gets cut on the sides and there is no horizontal scroll option. This commit adds a horizontal scroll when viewing the website on devices smaller than 480px.

How it would look: https://i.imgur.com/KMJLRs6.png

Cheers!