### PR TITLE
Add a copy/paste friendly example to promise docs

### DIFF
--- a/docs/promise.md
+++ b/docs/promise.md
@@ -13,6 +13,24 @@ Reason has built-in support for [JavaScript promises through BuckleScript](https
 Using the pipe operator (see "Composition operators" in the [Pervasives module](https://reasonml.github.io/api/Pervasives.html)):
 
 ```
+Js.Promise.make((~resolve, ~reject) => [@bs] resolve(2))
+|> Js.Promise.then_(value => {
+     Js.log(value);
+     Js.Promise.resolve(value + 2);
+   })
+|> Js.Promise.then_(value => {
+     Js.log(value);
+     Js.Promise.resolve(value + 3);
+   })
+|> Js.Promise.catch(err => {
+     Js.log2("Failure!!", err);
+     Js.Promise.resolve(-2);
+   });
+```
+
+You can also pass a promise as a function parameter like so:
+
+```
 let doSomethingToAPromise = (somePromise) => {
   somePromise
   |> Js.Promise.then_(value => {


### PR DESCRIPTION
Original example left out a copy/paste friendly example to play with in the playground.