### PR TITLE
Fix wrong `reason-cli` url

### DIFF
--- a/website/blog/2018-03-06-reason-3.1.0.md
+++ b/website/blog/2018-03-06-reason-3.1.0.md
@@ -8,4 +8,4 @@ Special shout-out to this version, as it fixes many bugs and comes with some lon
 - Tired of seeing `[@bs] foo(bar, baz)` for uncurrying? Use the new version to refmt your code to automatically format it into `foo(. bar, baz)`!
 - Trailing comma for everything, final function body item now formats to a trailing semicolon, `let%foo` extension sugar, fixes for comments, JSX, etc.
 
-Get the new version through [reason-cli](https://www.npmjs.com/package/reason-cli/) and through BuckleScript's bs-platform 2.2.2. Have fun!
+Get the new version through [reason-cli](https://www.npmjs.com/package/reason-cli) and through BuckleScript's bs-platform 2.2.2. Have fun!


### PR DESCRIPTION
`https://www.npmjs.com/package/reason-cli/` with end slash returns 404