### PR TITLE
Fixed really minor typo

### DIFF
--- a/docs/destructuring.md
+++ b/docs/destructuring.md
@@ -34,7 +34,7 @@ let (ten: int, twenty: int) = someInts;
 let {name: (n: string), age: (a: int)} = somePerson;
 ```
 
-Destructuring a functions' labeled arguments is also possible.
+Destructuring a function's labeled arguments is also possible.
 
 ```reason
 type person = {


### PR DESCRIPTION
English grammar:

A few functions' labels.
A function's label.