### PR TITLE
Remove comma in first example.

### DIFF
--- a/docs/interop.md
+++ b/docs/interop.md
@@ -9,9 +9,7 @@ If you're just hacking things together, this can be very nice, but you also have
 ```reason
 Js.log("this is reason");
 
-[%bs.raw {|
-console.log('here is some javascript for you');
-|}];
+[%bs.raw {| console.log('here is some javascript for you') |}];
 ```
 
 > `{|` and `|}` are the delimiters of a multi-line string in OCaml. You can also put a tag in there e.g. `{something|` and then it will look for a matching `|something}` to close.


### PR DESCRIPTION
Hi.
In 27fd7ceb89cd6041557aecf7f0ef115d9b81a824, it seems remove the `%` at the first example,
but if we use single `%`, it should contained as an expression.