### PR TITLE
Fix if-else typo in docs.

### DIFF
--- a/docs/if-else.md
+++ b/docs/if-else.md
@@ -12,7 +12,7 @@ let message = if (isMorning) {
 };
 ```
 
-**Note:** an `if-elseif-else` expression without the final `else` branch implicitly gives `()`. So this:
+**Note:** an `if-else` expression without the final `else` branch implicitly gives `()`. So this:
 
 ```reason
 if (showMenu) {


### PR DESCRIPTION
While going through the (excellent) Reason docs, I noticed a small `if-else` typo in the **`Note`** section – `if-else` is written twice 😱!

<img width="1268" alt="screen shot 2018-05-03 at 9 06 43 pm" src="https://user-images.githubusercontent.com/19421190/39612640-03d92f5e-4f16-11e8-8203-0d4a16fad687.png">

This PR fixes it 🚀!

<img width="1264" alt="screen shot 2018-05-03 at 9 03 40 pm" src="https://user-images.githubusercontent.com/19421190/39612651-18bee760-4f16-11e8-818b-862f2716fa8b.png">

