### PR TITLE
Adding 'install with yarn' to troubleshooting

### DIFF
--- a/docs/global-installation.md
+++ b/docs/global-installation.md
@@ -32,6 +32,12 @@ opam install reason.3.0.4 merlin.2.5.4
 
 If your installation fails, it might be because you're on npm 5.4.0 (`npm --version`). There was a known bug in npm that's fixed in 5.4.2. Upgrade `npm` and things should work.
 
+If _that_ fails, try using Yarn instead of npm (Yarn hides deep-path issues from OCaml):
+
+```
+yarn global add <package>
+```
+
 If _that_ fails, try https://github.com/reasonml/reasonml.github.io/pull/157. If that succeeds, please upvote that issue. We aren't sure it's the adequate fix in the meantime.
 
 Finally, if things still don't work, please file an issue at https://github.com/reasonml/reason-cli/issues. Sorry for the trouble.


### PR DESCRIPTION
Hi,
Just finished a two-hour session trying to figure out why Reason CLI tools won't install.
Apparently it choked on a path which it thought `is too deep inside filesystem, Esy won't be able to relocate binaries`.
This specific error was also silent, so I had to go into the esyBuildRelease shell script and make it spit it out.

This [issue](https://github.com/reasonml/reason-cli/issues/45) hinted using Yarn would do off with all that, and it did, installing quickly and happily. 

Might also be worth recommending Yarn as a default running for installing over npm, but I will leave that to more knowledgeable documentation editor.