### PR TITLE
 ReasonReact Greetings warning fixed

### DIFF
--- a/website/playground/try.js
+++ b/website/playground/try.js
@@ -202,7 +202,7 @@ input
   let make = _children => {
     ...component,
     render: _self =>
-      <button> (ReasonReact.stringToElement("Hello!")) </button>,
+      <button> (ReasonReact.string("Hello!")) </button>,
   };
 };
 


### PR DESCRIPTION
Changed ReasonReact.stringToElement to ReasonReact.string 
 
---
Warning number 3
OCaml preview 10:19-45

deprecated: ReasonReact.stringToElement
Please use ReasonReact.string instead