### PR TITLE
Fix reference to Reason objects

### DIFF
--- a/docs/record.md
+++ b/docs/record.md
@@ -127,7 +127,7 @@ getAge(kraken);
 getAge(me);
 ```
 
-The type system will complain that `me` is a `person`, and that `getAge` only works on `monster`. If you need such capability, use Reason objects, described [here](https://reasonml.github.io/docs/en/object.html).
+The type system will complain that `me` is a `person`, and that `getAge` only works on `monster`. If you need such capability, use Reason objects, described [here](object.md).
 
 ## Design Decisions
 

--- a/docs/record.md
+++ b/docs/record.md
@@ -127,7 +127,7 @@ getAge(kraken);
 getAge(me);
 ```
 
-The type system will complain that `me` is a `person`, and that `getAge` only works on `monster`. If you need such capability, use Reason objects, mentioned in the previous section.
+The type system will complain that `me` is a `person`, and that `getAge` only works on `monster`. If you need such capability, use Reason objects, described [here](https://reasonml.github.io/docs/en/object.html).
 
 ## Design Decisions
 


### PR DESCRIPTION
Currently, the previous section only has a link to Bucklescript's Object record mode, not really Reason objects.