### PR TITLE
search right language in search bar

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -269,7 +269,10 @@ const siteConfig = {
   },
   algolia: {
     apiKey: "966d1e412f67114a07dc0afe44b19b53",
-    indexName: "reason"
+    indexName: "reason",
+    algoliaOptions: {
+      facetFilters: ["lang:LANGUAGE"] 
+    }
   },
   disableHeaderTitle: true,
 };


### PR DESCRIPTION
## Motivation

Fixes #388 

## Notes
Only will work after https://github.com/algolia/docsearch-configs/pull/443 is merged

## Test Plan
```
cd website
yarn start
```

Choose different language, type in the search bar any keyword, should search only that language