### PR TITLE
Add a simple example of creating a reason object

### DIFF
--- a/docs/object.md
+++ b/docs/object.md
@@ -32,6 +32,25 @@ Two dots, also called an elision, indicate that this is an "open" object type, a
 
 ### Creation
 
+## Simple
+
+```reason
+type tesla = {
+  .
+  color: string,
+};
+
+let obj: tesla = {
+  pub color = "Red"
+};
+
+Js.log(obj#color) /* "Red" */
+```
+
+Here we have a simple object with only a color property. When we create the object we set the color property to be public and assign it the value `"Red"`. Because `color` is a public property we can access it using object notation and log it to the console. 
+
+## Advanced
+
 ```reason
 type tesla = {.
   drive: int => int

--- a/docs/object.md
+++ b/docs/object.md
@@ -41,13 +41,14 @@ type tesla = {
 };
 
 let obj: tesla = {
-  pub color = "Red"
+  val red = "Red";
+  pub color = red;
 };
 
 Js.log(obj#color) /* "Red" */
 ```
 
-Here we have a simple object with only a color property. When we create the object we set the color property to be public and assign it the value `"Red"`. Because `color` is a public property we can access it using object notation and log it to the console. 
+Here we have a simple object with the method `color` and the property `red`. This method takes no arguments and returns the private proptery `red`. Because the method `color` is a public method we can access it using object notation. Remember, objects only export methods and all properties are private.
 
 ## Advanced
 


### PR DESCRIPTION
Maybe I am just slow but when I first looked at the docs on objects I was stumped on how to create a simple object. After fooling around with it for about 20 min I finally figured out how they work. Coming from a JS background, objects don't have the idea of public and private methods in an explicit sense. In constructors, yes, but in plain ole' objects no, which is what I think of when I think of objects. I added a simple example, and referenced the other as advanced. I think the example I added shows how to create an object in its most simplest form while also referencing the very first example at the start of the doc. I think this would help newcomers, and advanced developers, to recognize that an object behaves much more like a constructor than an object, in the JS sense, and reduce confusion going forward in the doc.