### PR TITLE
Replace confusing ReasonReact instructions

### DIFF
--- a/docs/quickstart-javascript.md
+++ b/docs/quickstart-javascript.md
@@ -24,5 +24,5 @@ When developing, instead of running `npm run build` each time, run `npm run star
 Next:
 
 - Read more about how we compile to JavaScript through our partner project, [BuckleScript](https://bucklescript.github.io).
-- Alternatively, **to start a [ReasonReact](//reasonml.github.io/reason-react/docs/en/installation.html) app**, try `bsb -init my-react-app -theme react`.
+- Alternatively, **to start a [ReasonReact](//reasonml.github.io/reason-react/docs/en/installation.html) app**, follow the instructions [here](https://reasonml.github.io/reason-react/docs/en/installation).
 - Head over to [Editor Setup](global-installation.md) to get the Reason plugin for your favorite editor!


### PR DESCRIPTION
If people try to follow the instructions on the Quickstart page, and then enter the command shown to use the 'react' theme for bsb -init, they will encounter a compiler error due to the fact that npm install hasn't been run. This is not a great first experience.

Additionally, the instructions on this page describe running the code under node, which really makes no sense for ReasonReact. We'd really be better off just having them go to the ReasonReact instructions instead.