### PR TITLE
Update quickstart-javascript.md

### DIFF
--- a/docs/quickstart-javascript.md
+++ b/docs/quickstart-javascript.md
@@ -21,6 +21,8 @@ We use the BuckleScript compiler to compile Reason to JavaScript, then we use No
 
 When developing, instead of running `npm run build` each time, run `npm run start` to start a watcher that recompiles on file change.
 
+By default, the `basic-reason` theme configures BuckleScript to output compiled JavaScript files to the `src` directory, alongside the Reason files they were produced from. If you prefer to keep your handwritten and generated files separate, editing `bsconfig.json` to set `in-source` to `false` will cause the compiled files to be output to the `lib` directory instead.
+
 Next:
 
 - Read more about how we compile to JavaScript through our partner project, [BuckleScript](https://bucklescript.github.io).


### PR DESCRIPTION
The default behavior of the quickstart project is to put compiled files alongside source files and includes them in git, which is very unusual for a compile-to-JS language, and goes against the expectations/best practices of developers who are used to other such languages. [This post](https://reasonml.chat/t/should-i-include-or-exclude-bs-js-files-in-git/60) makes it sound like this is a common source of confusion. It would likely be less friction for such developers if the behavior of the quickstart project was to put compiled files in `lib` by default, but short of this an explanation of how to change this behavior would be helpful.