### PR TITLE
Clarify use of ~ in labeled arguments

### DIFF
--- a/docs/function.md
+++ b/docs/function.md
@@ -63,7 +63,7 @@ let addCoordinates = (x, y) => {
 addCoordinates(5, 6); /* which is x, which is y? */
 ```
 
-In OCaml/Reason, you can attach labels to an argument:
+In OCaml/Reason, you can attach labels to an argument by prefixing the name with the `~` symbol:
 
 ```reason
 let addCoordinates = (~x, ~y) => {


### PR DESCRIPTION
A developer on my team experienced some confusion with the `~` symbol in front of labeled arguments. I thought it might make things clearer to explicitly point out its usage.