### PR TITLE
Add padding to API docs

### DIFF
--- a/website/static/css/api.css
+++ b/website/static/css/api.css
@@ -10,7 +10,7 @@
 }
 
 .ocamldoc {
-  padding-top: 24px;
+  padding: 24px 12px 0;
   font-size: 100%;
   line-height: 1.8rem;
 }


### PR DESCRIPTION
I noticed that with the contents of the API docs pushed up against the edge of screen, it can get a little difficult to read at times. Adding a little padding makes things a little easier on the eyes ✨ 

Here's what it looks like with the extra padding.

<img width="837" alt="screen shot 2018-08-23 at 6 36 23 pm" src="https://user-images.githubusercontent.com/20060118/44560515-04ae3180-a705-11e8-989a-223d8d97fd81.png">
