### PR TITLE
Add note about reason-cli tools

### DIFF
--- a/docs/editor-plugins.md
+++ b/docs/editor-plugins.md
@@ -15,6 +15,8 @@ And other features.
 
 ## Officially Supported Editors
 
+**Note:** You'll also need to globally install the [reason-cli tools](https://github.com/reasonml/reason-cli) for these integrations to work.
+
 - [VSCode](https://github.com/jaredly/reason-language-server): **recommended**.
 - [Atom](https://github.com/reasonml-editor/atom-ide-reason)
 - [Vim/Neovim](https://github.com/reasonml-editor/vim-reason-plus)


### PR DESCRIPTION
It seems to me that these editor integrations won't work without reason-cli tools. I don't see anything in the current install instructions which includes them.