### PR TITLE
editor-plugins: link to reason-vscode extension

### DIFF
--- a/docs/editor-plugins.md
+++ b/docs/editor-plugins.md
@@ -15,9 +15,9 @@ And other features.
 
 ## Officially Supported Editors
 
-- [VSCode](https://github.com/jaredly/reason-language-server): **recommended**.
+- [VSCode](https://github.com/jaredly/reason-language-server): **Recommended**. Search for [reason-vscode](https://marketplace.visualstudio.com/items?itemName=jaredly.reason-vscode) in the extensions marketplace.
 - [Atom](https://github.com/reasonml-editor/atom-ide-reason)
 - [Vim/Neovim](https://github.com/reasonml-editor/vim-reason-plus)
 - [Sublime Text](https://github.com/reasonml-editor/sublime-reason)
 - [IDEA](https://github.com/reasonml-editor/reasonml-idea-plugin)
-- [Emacs](https://github.com/reasonml-editor/reason-mode): **this is currently unmaintained**. We'd like to upgrade it to [reason-language-server](https://github.com/jaredly/reason-language-server) one day. Contribution welcome!
+- [Emacs](https://github.com/reasonml-editor/reason-mode): **Currently unmaintained**. We'd like to upgrade it to [reason-language-server](https://github.com/jaredly/reason-language-server) one day. Contributions welcome!


### PR DESCRIPTION
Show the actual extension name so people can immediately know how to install it. This avoids confusion because the repository is named for the language server. The extension website prominently displays install instructions at the top.