### PR TITLE
Vertically aligning superscript

### DIFF
--- a/website/static/css/api.css
+++ b/website/static/css/api.css
@@ -220,3 +220,7 @@
   font-family: Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
   padding-bottom: 16px;
 }
+sup.superscript {
+  vertical-align: super;
+  font-size: 0.7rem;
+}


### PR DESCRIPTION
Fixes #433 

Changes `sup` tags inside the documentation that render like [this](https://reasonml.github.io/api/Int32.html#VALmax_int):

> let max_int: int32;
> 
> The greatest representable 32-bit integer, 231 - 1.

To:

> let max_int: int32;
> 
> The greatest representable 32-bit integer, 2<sup>31 - 1</sup>.