### PR TITLE
Add word to make more searchable

### DIFF
--- a/docs/function.md
+++ b/docs/function.md
@@ -63,7 +63,7 @@ let addCoordinates = (x, y) => {
 addCoordinates(5, 6); /* which is x, which is y? */
 ```
 
-In OCaml/Reason, you can attach labels to an argument by prefixing the name with the `~` symbol:
+In OCaml/Reason, you can attach labels to an argument by prefixing the name with the `~` symbol (also known as tilde):
 
 ```reason
 let addCoordinates = (~x, ~y) => {


### PR DESCRIPTION
It's easier to search for "tilde" than for "~".