### PR TITLE
Fix Reason syntax for `true`, `false` in cheatsheet

### DIFF
--- a/docs/syntax-cheatsheet.md
+++ b/docs/syntax-cheatsheet.md
@@ -25,7 +25,7 @@ We've worked very hard to make Reason look like JS while preserving OCaml's grea
 
 | JavaScript                                            | Reason                                         |
 | ----------------------------------------------------- | ---------------------------------------------- |
-| `true`, `false`                                       | `true`, `false`                                |
+| `true`, `false`                                       | Same                                |
 | `!true`                                               | Same                                           |
 | <code>&#124;&#124;</code>, `&&`, `<=`, `>=`, `<`, `>` | Same                                           |
 | `a === b`, `a !== b`                                  | Same                                           |


### PR DESCRIPTION
I've never used Reason before but was looking through the docs for the first time today and was confused about this. Are the values for `true`, `false` the same in JavaScript and Reason?