### PR TITLE
Change name from `Fast Pipe` to `Pipe First`

### DIFF
--- a/docs/fast-pipe.md
+++ b/docs/fast-pipe.md
@@ -1,5 +1,5 @@
 ---
-title: Fast Pipe
+title: Pipe First
 ---
 
 `->` is a convenient operator that allows you to "flip" your code inside-out. `a(b)` becomes `b->a`. It's a piece of syntax that doesn't have any runtime cost.


### PR DESCRIPTION
I'm aware this is a radical change and this PR can be a place for discussion first.

When teaching Reason people asked: Why is it called `fast pipe`? In addition they regularly find the pipe operator and then get really confused that they are not doing the same.

My suggestion would be  to establish a consistent naming theme for both pipe operators:
- Pipe first `->`
- Pipe last `|>`

Advantage of this convention is that it's very easy to use in the natural language when teaching.

This partly based on a discussion on the #bikeshedding thread in Discord. Thanks to @ryyppy for bringing it up 👍 /cc @jordwalke