### PR TITLE
Add ReasonConf2019 promo banner

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -109,6 +109,10 @@ class HomeSplash extends React.Component {
               <img alt={siteConfig.title} src={`${siteConfig.baseUrl}img/reason.svg`} />
             </div>
 
+            <div className="homeWrapperPromo">
+              ReasonConf 2019 is happening in Europe on April 11th - 13th.<br/>
+              <a href="https://www.reason-conf.com" target="_blank"> Get your tickets soon! </a>
+            </div>
             <div className="homeWrapperInner">
               <div className="homeCodeSnippet">
                 <MarkdownBlock>{codeExampleSmallScreen}</MarkdownBlock>

--- a/website/static/css/reason.css
+++ b/website/static/css/reason.css
@@ -189,3 +189,16 @@ table .hljs {
   background-color: $primaryColor;
   color: white;
 }
+
+/* Promotion related stuff for frontpage */
+
+.homeWrapperPromo {
+  font-size: 1.5rem;
+  margin-top: 40px;
+  margin-bottom: 3rem;
+}
+
+.homeWrapperPromo a {
+  font-weight: bold;
+  text-decoration: underline;
+}


### PR DESCRIPTION
Would be glad if we could get this merged.
I would also take care of removing it as soon as the event is over.

![image](https://user-images.githubusercontent.com/1121889/51089401-b14c8680-176c-11e9-8f03-02cf8b9b98d0.png)

\cc @rickyvetter @jordwalke @cristianoc 