### PR TITLE
Update command on native quick start

### DIFF
--- a/docs/quickstart-ocaml.md
+++ b/docs/quickstart-ocaml.md
@@ -13,7 +13,7 @@ opam init
 # **Note**: add the line below to your ~/.bashrc or ~/.zshrc too; it's needed at every shell startup
 eval $(opam config env)
 opam update
-opam switch 4.02.3
+opam switch create 4.02.3
 ```
 
 Then clone our example [`ReasonNativeProject`](https://github.com/reasonml/ReasonNativeProject) repo, and you're good to go!


### PR DESCRIPTION
I received the following error when running `opam switch 4.02.3`.

```
[ERROR] No switch 4.02.3 is currently installed. Did you mean 'opam switch create
        4.02.3'?
        Installed switches are:
          - default
```

Instead for me `opam switch create 4.02.3` worked.