### PR TITLE
Update Reason local scope example

### DIFF
--- a/docs/comparison-to-ocaml.md
+++ b/docs/comparison-to-ocaml.md
@@ -124,7 +124,11 @@ imperativeFunc 0 0</code></pre>
 end</code></pre>
       </td>
       <td>
-        Same as above
+        <pre><code>{
+  let ten = 10;
+  imperativeFunc(ten, ten);
+  imperativeFunc(0, 0);
+}</code></pre>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
To exactly match the semantics implied by the OCaml syntax, i.e. the visibility of `ten`.