### PR TITLE
Remove ReasonConf advertisement

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -109,10 +109,7 @@ class HomeSplash extends React.Component {
               <img alt={siteConfig.title} src={`${siteConfig.baseUrl}img/reason.svg`} />
             </div>
 
-            <div className="homeWrapperPromo">
-              ReasonConf 2019 is happening in Europe on April 11th - 13th.<br/>
-              <a href="https://www.reason-conf.com" target="_blank"> Get your tickets soon! </a>
-            </div>
+            <div className="homeWrapperPromo"></div>
             <div className="homeWrapperInner">
               <div className="homeCodeSnippet">
                 <MarkdownBlock>{codeExampleSmallScreen}</MarkdownBlock>


### PR DESCRIPTION
Since the conf is over, it felt weird to see that on the homepage.  I kept the promo `div` wrapper so other things can be advertised later (ReasonConf US? 😉)