### PR TITLE
Remove ReasonConf 2019 advert

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -109,10 +109,13 @@ class HomeSplash extends React.Component {
               <img alt={siteConfig.title} src={`${siteConfig.baseUrl}img/reason.svg`} />
             </div>
 
+            {/* Keep this section for future events! */}
+            {/*
             <div className="homeWrapperPromo">
               ReasonConf 2019 is happening in Europe on April 11th - 13th.<br/>
               <a href="https://www.reason-conf.com" target="_blank"> Get your tickets soon! </a>
             </div>
+            */}
             <div className="homeWrapperInner">
               <div className="homeCodeSnippet">
                 <MarkdownBlock>{codeExampleSmallScreen}</MarkdownBlock>


### PR DESCRIPTION
The conference is over. I only commented out the event advertisement section, so we can reuse it for future events!