### PR TITLE
Fix overlay error height

### DIFF
--- a/website/static/css/try.css
+++ b/website/static/css/try.css
@@ -199,7 +199,6 @@
   padding: 0px 15px;
   background-color: rgb(39, 41, 44);
   overflow: scroll;
-  flex: 1;
   line-height: 15px;
 }
 


### PR DESCRIPTION
Remove (flex: 1)  to prevent error overlay from hiding the last line in the editor.