### PR TITLE
Update section about exposing external functions to ReasonML to be less confusing.

### DIFF
--- a/docs/interop.md
+++ b/docs/interop.md
@@ -136,9 +136,9 @@ let ctx = getContext(myCanvas, "2d");
 
 So let's unpack what's going on. We created some abstract types for the Canvas DOM node and the associated RenderingContext object.
 
-Then we made a `getContext` function, but instead of `@bs.val` we used `@bs.send`, and we used an empty string for the text of the external. `@bs.send` means "we're calling a method on the first argument", which in this case is the canvas. Given the above, BuckleScript will translate `getContext(theFirstArgument, theSecondArgument)` into `theFirstArgument.getContext(theSecondArgument, ...)`.
+Then we made a `getContext` function, but instead of `@bs.val` we used `@bs.send`, and we provided the name of the function in JavaScript as a string value. `@bs.send` means "we're calling a method on the first argument", which in this case is the canvas. Given the above, BuckleScript will translate `getContext(theFirstArgument, theSecondArgument)` into `theFirstArgument.getContext(theSecondArgument, ...)`.
 
-The empty string means "the JS name is the same as the name we're giving the external in BuckleScript-land" – in this case `getContext`. If we wanted to name it something else (like `getRenderingContext`), then we'd have to supply the string `"getContext"` so that BuckleScript calls the right function.
+The name of the JavaScript function does not need to match the name of the function within Reason. In a form of punning, the string could be empty (i.e., ""), which is a special value that means "the JS name is the same as the name we're giving the external in BuckleScript-land" – in this case `getContext`. If we wanted to name the Reason function something else (like `getRenderingContext`), then we'd have to supply the string `"getContext"` so that BuckleScript calls the right function.
 
 Let's add one more function just so it's interesting.
 


### PR DESCRIPTION
The interop documentation used to use an empty string for the JavaScript function name, but that was changed in 3e35eefc67f8513c9b7d95ab2c80563274a6d1c4. Unfortunately, a portion of the text describing how the empty string works wasn't updated and thus made for some confusion.

NB: I'm pretty new to Reason still, so I don't actually know if this is considered a form of punning or not. I just tried to relate what I had read previously in the documentation to what I was looking at currently.