### PR TITLE
Added link to DEV’s Reason topic.

### DIFF
--- a/docs/community.md
+++ b/docs/community.md
@@ -11,6 +11,7 @@ Come say hi!
 - [Twitter](https://twitter.com/reasonml)
 - [Reddit](https://www.reddit.com/r/reasonml/)
 - [Stack Overflow](http://stackoverflow.com/questions/tagged/reason)
+- [DEV](https://dev.to/t/reason)
 
 ## GitHub
 


### PR DESCRIPTION
DEV is a popular site for people to blog about Reason. This just adds a link to it in the documentation’s community page. (ReactJS’s docs also link to the React DEV topic.)