### PR TITLE
Fix #375 - Try error messages not showing up in FF.

### DIFF
--- a/website/static/css/try.css
+++ b/website/static/css/try.css
@@ -190,6 +190,7 @@
   display: flex;
   flex: 1;
   flex-direction: column;
+  min-height: 0;
 }
 
 .try-error-warning {


### PR DESCRIPTION
As soon as you have a scrollbar, you cannot see the error output on Firefox anymore.

![image](https://user-images.githubusercontent.com/18074327/66760849-2dfac580-eea3-11e9-84d7-944908e597f9.png)

but with this little fix, it works:

![image](https://user-images.githubusercontent.com/18074327/66760954-5da9cd80-eea3-11e9-92e9-7d9b9458d799.png)
