### PR TITLE
Recommend to use reason-language-server for emacs

### DIFF
--- a/docs/editor-plugins.md
+++ b/docs/editor-plugins.md
@@ -20,7 +20,7 @@ And other features.
 - [Vim/Neovim](https://github.com/reasonml-editor/vim-reason-plus)
 - [Sublime Text](https://github.com/reasonml-editor/sublime-reason)
 - [IDEA](https://github.com/reasonml-editor/reasonml-idea-plugin)
-- [Emacs](https://github.com/reasonml-editor/reason-mode): **Currently unmaintained**. We'd like to upgrade it to [reason-language-server](https://github.com/jaredly/reason-language-server) one day. Contributions welcome!
+- [Emacs](https://github.com/reasonml-editor/reason-mode): **Currently unmaintained** It's recommended to use [reason-language-server](https://github.com/jaredly/reason-language-server) rather than [merlin.el](https://github.com/ocaml/merlin/blob/master/emacs/merlin.el).
 
 ## Native Project Development (Community Supported):
 


### PR DESCRIPTION
Edit: Actually having clicked create on this PR after forgetting to yesterday, I remember that I have run into some trouble with the language server: it hangs on pasting text sometimes, I had to hack the lsp-mode.el source code to silence that for now.  I'm trying to figure out why that happens, maybe I'll make some progress with that in the next few days...

I don't know exactly what was meant by upgrading reason-mode to use reason-language-server so I removed that text.
I'm pretty sure this wording is better than the status quo: even after hacking elisp and experimenting with merlin on the command line, I wasn't able to get it to recognize that my file was Reason code rather than OCaml.  With LSP it seems to be working fine for me so far, using the spacemacs layer (aside from merlin still running and generating errors sometimes -- I'll try and find time to investigate how to kill that off and update the spacemacs layer later on).