### PR TITLE
fix typo in integer-and-float.md

### DIFF
--- a/docs/integer-and-float.md
+++ b/docs/integer-and-float.md
@@ -34,4 +34,4 @@ We provide [a few helpers in the standard library](https://bucklescript.github.i
 
 "Why the heck can't I just use `+` for both int and float?"
 
-This is due to some unforunate constraints in the language's type system. They can be worked out in the future.
+This is due to some unfortunate constraints in the language's type system. They can be worked out in the future.


### PR DESCRIPTION
This PR fixes a typo: unforunate => unfortunate