### PR TITLE
fixed typos in what-and-why docs

### DIFF
--- a/docs/what-and-why.md
+++ b/docs/what-and-why.md
@@ -45,7 +45,7 @@ Many backing languages would satisfy the previous section's points; the points b
 Here are some alternatives that share some similar concepts/lineage with Reason/OCaml, but often with a different focus:
 
 - [OCaml](http://ocaml.org). Reason is a syntax and toolchain built on top of the OCaml language. OCaml and Reason interoperate with each other. You can compile plain OCaml with BuckleScript, and [Js_of_ocaml](http://ocsigen.org/js_of_ocaml/) can work with Reason as well.
-- [Rust](http://rust-lang.org). Inspired by the ML family of langauges, but not garbage collected. Has excellent parallelism support.
+- [Rust](http://rust-lang.org). Inspired by the ML family of languages, but not garbage collected. Has excellent parallelism support.
 - [Elm](http://elm-lang.org). Another great language in the ML family. Focuses on building web applications. See the widely praised talk on Elm, [Let's Be Mainstream](https://www.youtube.com/watch?v=oYk8CKH7OhE).
 - [PureScript](http://www.purescript.org). Inspired by Haskell, compiles to the JavaScript.
 - [Fable](http://fable.io/). Based on F#, which is closely related to OCaml.

--- a/docs/what-and-why.md
+++ b/docs/what-and-why.md
@@ -44,7 +44,7 @@ Many backing languages would satisfy the previous section's points; the points b
 
 Here are some alternatives that share some similar concepts/lineage with Reason/OCaml, but often with a different focus:
 
-- [OCaml](http://ocaml.org). Reason is a syntax and toolchain built on top of the OCaml language. OCaml and Reason interoperate with eachother OCaml. You can compile plain OCaml with BuckleScript, and [Js_of_ocaml](http://ocsigen.org/js_of_ocaml/) can work with Reason as well.
+- [OCaml](http://ocaml.org). Reason is a syntax and toolchain built on top of the OCaml language. OCaml and Reason interoperate with each other. You can compile plain OCaml with BuckleScript, and [Js_of_ocaml](http://ocsigen.org/js_of_ocaml/) can work with Reason as well.
 - [Rust](http://rust-lang.org). Inspired by the ML family of langauges, but not garbage collected. Has excellent parallelism support.
 - [Elm](http://elm-lang.org). Another great language in the ML family. Focuses on building web applications. See the widely praised talk on Elm, [Let's Be Mainstream](https://www.youtube.com/watch?v=oYk8CKH7OhE).
 - [PureScript](http://www.purescript.org). Inspired by Haskell, compiles to the JavaScript.


### PR DESCRIPTION
eachother OCaml -> each other
langauges -> languages