### PR TITLE
Fix code sample to match docs

### DIFF
--- a/docs/interop.md
+++ b/docs/interop.md
@@ -127,7 +127,7 @@ type context;
 
 /* we're leaving these types abstract, because we won't
  * be using them directly anywhere */
-[@bs.send] external getContext : (canvas, string) => context = "getContext";
+[@bs.send] external getContext : (canvas, string) => context = "";
 
 let myCanvas: canvas = [%bs.raw {| document.getElementById("mycanvas") |}];
 


### PR DESCRIPTION
Per the docs, the external text should be an empty string, not `"getContext"`