### PR TITLE
Document removing this binding from objects

### DIFF
--- a/docs/object.md
+++ b/docs/object.md
@@ -95,3 +95,12 @@ You can use the above object like so:
 ```reason
 obj#doYouWant();
 ```
+
+To disable the `this` binding you can use `as`.
+```reason
+let makeMyObject () =>
+{
+  as _;
+  pub = doYouWant () => true;
+}
+```


### PR DESCRIPTION
Add documentation for removing the this binding, which can result in an unused variable warning.