### PR TITLE
Fix typos

### DIFF
--- a/docs/function.md
+++ b/docs/function.md
@@ -11,7 +11,7 @@ There is a comprehensive [Cheat-sheet](#cheat-sheet) at the end.
 
 ## The Basics
 
-Define named functions with a [let binding](let-binding.md), parenthesis `()`,
+Define named functions with a [let binding](let-binding.md), parentheses `()`,
 and an arrow `=>`:
 
 ```reason
@@ -42,12 +42,12 @@ have "no arguments". This is commonly used when a function has side-effects.
 The unit argument looks like `()`:
 
 ```reason
-let launchMissle = () => {
+let launchMissile = () => {
   someSideEffects();
-  print_endline("Missles have been launched!");
+  print_endline("Missiles have been launched!");
 };
 
-launchMissle();
+launchMissile();
 ```
 
 ## Named Arguments
@@ -216,7 +216,7 @@ fn(~data=x, ());
 ```
 
 Reason provides a shorthand syntax for the pattern above. Prefixing a named
-argument's value with a question mark at the call site, will pass whatever is
+argument's value with a question mark at the call site will pass whatever is
 inside of the `Some()`, but if the value is `None`, then the named argument
 will not be supplied at all.
 
@@ -236,7 +236,7 @@ values too._
 
 #### Referencing Previous Arguments
 
-When defining default values previous arguments may be used:
+When defining default values, previous arguments may be used:
 
 ```reason
 let add = (a, ~b, ~c=a+1, ~d=b+1, ()) => a + b + c + d;
@@ -247,7 +247,7 @@ add(1, ~b=1, ~c=10, ()); /* 14 */
 
 ## No Var-args
 
-This is no way to define a function that accepts a variable number of arguments
+There is no way to define a function that accepts a variable number of arguments
 in Reason. A workaround can be to accept a list as the final argument.
 
 ## Cheat-sheet


### PR DESCRIPTION
Noticed "missiles" was spelled wrong. While I was in there, made some other typographical suggestions.