### PR TITLE
fix: missing yarn install step

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,6 +26,7 @@ To compile & run the project you just created:
 
 ```sh
 cd my-new-project
+yarn # to install dependencies
 yarn build # or npm run build, for npm
 node src/Demo.bs.js
 ```


### PR DESCRIPTION
First up, massive massive props for making it relatively easy to edit your documentation and suggest PRs on it. Well done there!

I was going through the installation instruction today (new reason user) and I noticed this was missing.
For seasoned JS devs used to yarn/npm, it's obvious what to do, but I thought it wouldn't hurt to add it for anyone else.