### PR TITLE
Updated "bsb -init" example

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,7 +19,7 @@ yarn global add bs-platform
 The global installation comes with a simple project generator. Try:
 
 ```sh
-bsb -init my-new-project -theme basic-reason
+bsb -init my-new-project -theme basic
 ```
 
 To compile & run the project you just created:


### PR DESCRIPTION
Old example gives:
```
$ bsb -init my-new-project -theme basic-reason
Making directory my-new-project                      
Available themes:                
basic                                                                                              
generator                                
minimal                                      
node                       
react-hooks                                                         
react-starter                                                         
tea                                                       
Error: theme basic-reason not found
```