### PR TITLE
Change basic-reason to basic

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,7 +19,7 @@ yarn global add bs-platform
 The global installation comes with a simple project generator. Try:
 
 ```sh
-bsb -init my-new-project -theme basic-reason
+bsb -init my-new-project -theme basic
 ```
 
 To compile & run the project you just created:


### PR DESCRIPTION
# Why?
Running with the current instructions will yield:

```
$ bsb -init my-first-app -theme basic-reason                                                         ‹ruby-2.6.3›
Making directory my-first-app
Available themes:
basic
generator
minimal
node
react-hooks
react-starter
tea
Error: theme basic-reason not found
```