### PR TITLE
recursion: fix multiple definition of the type name t

### DIFF
--- a/docs/recursion.md
+++ b/docs/recursion.md
@@ -76,10 +76,10 @@ Opt-out of recursive types using the `nonrec` keyword:
 
 ```reason
 type t = string;
-type nonrec t = list(t);
+type nonrec t' = list(t);
 
-/* t is now list(string) */
-let x: t = ["hello", "world"];
+/* t' is now list(string) */
+let x: t' = ["hello", "world"];
 ```
 
 ## Mutually Recursive Types


### PR DESCRIPTION
Example of [Recursive Types](https://reasonml.github.io/docs/en/recursion#recursive-types) gives the following error:
```
Error: Multiple definition of the type name t.
       Names must be unique in a given structure or signature.
```
Fixed it by renaming the second type name.