### PR TITLE
Fix misleading example of open object types

### DIFF
--- a/docs/object.md
+++ b/docs/object.md
@@ -26,7 +26,7 @@ type car('a) = {
 } as 'a;
 ```
 
-Two dots, also called an elision, indicate that this is an "open" object type, and therefore can also contain other values and methods. An open object is also polymorphic and therefore requires a parameter.
+Two dots, also called an elision, indicate that this is an "open" object type, and therefore can also contain other values and methods. An open object is also polymorphic and therefore requires a parameter. This parameter refers to the complete type of the object, including those other values and methods.
 
 ### Creation
 
@@ -77,7 +77,9 @@ type tesla('a) = {
   drive: int => int
 } as 'a;
 
-let obj: tesla({. drive: int => int, doYouWant: unit => bool}) = {
+let driveInterstate = (t: tesla('a)) => t#drive(60);
+
+let obj: {. drive: int => int, doYouWant: unit => bool} = {
   val hasEnvy = ref(false);
   pub drive = (speed) => {
     this#enableEnvy(true);
@@ -91,5 +93,6 @@ let obj: tesla({. drive: int => int, doYouWant: unit => bool}) = {
 You can use the above object like so:
 
 ```reason
+driveInterstate(obj);
 obj#doYouWant();
 ```


### PR DESCRIPTION
The given example using an open object type isn't how one would actually use it. The point of an open object type is so one can write code that works across multiple concrete object types that share some, but not all, of their fields. I made it so that the example is closer to how one would actually use the language feature to achieve this purpose.

Also, I think there's a lot of room for improvement for the Object page as a whole. What do other people think?