### PR TITLE
Updating Installation Docs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,6 +5,7 @@ title: Installation
 This page is a detailed explanation on how to install Reason with [opam](https://opam.ocaml.org/), both manually and using a template. There are other options available, such as [esy](https://esy.sh), but we recommend using opam for the best experience. Check the [esy installation page](installation-esy.md) if you want to use esy instead.
 
 ### System requirements
+
 - macOS and Linux are supported natively
 - Windows is supported via WSL (https://ocaml.org/docs/ocaml-on-windows)
 
@@ -74,24 +75,37 @@ opam install dune
 To wrap up the installation process, let's create a simple hello world project. With the basic setup done:
 
 Create a file `hello.re` with the following content:
+
 ```
 print_endline("Hello world!");
 ```
 
+Create a file `dune-project` with the following content (check [dune.build](https://dune.build/) for latest version):
+
+```
+(lang dune 3.6)
+```
+
+Create an empty file `hello.opam`
+
 Create a file `dune` with the following content:
+
 ```
 (executable
  (name hello)
  (public_name hello))
 ```
+
 > Note: dune uniformly uses the .exe extension to build native executables, even on Unix where programs don’t usually have a .exe extension.
 
 The `executable` stanza is used to define executables and the `name` field is used to specify the name of the executable (Can run with `dune exec src/hello.exe`). The `public_name` field is used to specify the name of the executable when it is installed and allows you to run the executable with `hello` directly: `dune exec hello`.
 
 Run the project (this will compile the project and run the executable):
+
 ```
 dune exec hello
 ```
+
 If you want to build only:
 
 ```


### PR DESCRIPTION
If you follow the current instructions for creating a hello world project, when running `dune exec hello` you receive the following error:

```
Error: I cannot find the root of the current workspace/project.
If you would like to create a new dune project, you can type:

    dune init project NAME

Otherwise, please make sure to run dune inside an existing project or
workspace. For more information about how dune identifies the root of the
current workspace/project, please refer to
https://dune.readthedocs.io/en/stable/usage.html#finding-the-root
```

I believe this has to do with the changed behavior of `dune` exec/build which will not create a `dune-project` for you anymore if it is missing.

After creating the file with the minimum required contents as seen on [dune.build](https://dune.build/), the next error received is:

```
File "dune", line 1, characters 0-47:
1 | (executable
2 |  (name hello)
3 |  (public_name hello))
Error: The current project defines some public elements, but no opam packages
are defined.
Please add a <package>.opam file at the project root so that these elements
are installed into it.
```

If you dutifully follow the suggestion and add an empty `hello.opam` the project will build the exe and execute the binary

```
❯ dune build hello.exe
❯ dune exec hello
Hello, World!
```

It is of course possible that I missed a step, but this seems to be the minimum viable project, i.e as opposed to doing `dune init proj ...`

 